### PR TITLE
chore: remove addDefaultOperationMiddlewares

### DIFF
--- a/Packages/ClientRuntime/Sources/Middleware/OperationStack.swift
+++ b/Packages/ClientRuntime/Sources/Middleware/OperationStack.swift
@@ -30,15 +30,6 @@ public struct OperationStack<OperationStackInput: Encodable & Reflection,
         
     }
     
-    /// This function if called adds all default middlewares to a typical sdk operation,
-    ///  can optionally call from the service client inside an operation
-    public mutating func addDefaultOperationMiddlewares() {
-        finalizeStep.intercept(position: .before, middleware: ContentLengthMiddleware<OperationStackOutput,
-                                                                                   OperationStackError>())
-        deserializeStep.intercept(position: .after, middleware: DeserializeMiddleware<OperationStackOutput,
-                                                                                       OperationStackError>())
-    }
-    
     /// This execute will execute the stack and use your next as the last closure in the chain
     public func handleMiddleware<H: Handler>(context: HttpContext,
                                              input: OperationStackInput,

--- a/Packages/ClientRuntime/Sources/Networking/Http/Middlewares/DeserializeMiddleware.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/Middlewares/DeserializeMiddleware.swift
@@ -5,7 +5,7 @@ public struct DeserializeMiddleware<Output: HttpResponseBinding,
                                     OutputError: HttpResponseBinding>: Middleware {
     
     public var id: String = "Deserialize"
-    
+    public init() {}
     public func handle<H>(context: Context,
                           input: SdkHttpRequest,
                           next: H) -> Result<OperationOutput<Output>, SdkError<OutputError>>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
+
 kotlin.code.style=official
 
 # config

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
-
 kotlin.code.style=official
 
 # config

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ClientRuntimeTypes.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ClientRuntimeTypes.kt
@@ -54,7 +54,9 @@ object ClientRuntimeTypes {
         val OperationOutput = runtimeSymbol("OperationOutput")
         val Middleware = runtimeSymbol("Middleware")
         val LoggerMiddleware = runtimeSymbol("LoggerMiddleware")
+        val ContentLengthMiddleware = runtimeSymbol("ContentLengthMiddleware")
         val ContentMD5Middleware = runtimeSymbol("ContentMD5Middleware")
+        val DeserializeMiddleware = runtimeSymbol("DeserializeMiddleware")
         val MutateHeadersMiddleware = runtimeSymbol("MutateHeadersMiddleware")
         val OperationStack = runtimeSymbol("OperationStack")
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpBindingProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpBindingProtocolGenerator.kt
@@ -38,6 +38,8 @@ import software.amazon.smithy.swift.codegen.SwiftTypes
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.integration.codingKeys.CodingKeysGenerator
 import software.amazon.smithy.swift.codegen.integration.httpResponse.HttpResponseGeneratable
+import software.amazon.smithy.swift.codegen.integration.middlewares.ContentLengthMiddleware
+import software.amazon.smithy.swift.codegen.integration.middlewares.DeserializeMiddleware
 import software.amazon.smithy.swift.codegen.integration.middlewares.LoggingMiddleware
 import software.amazon.smithy.swift.codegen.integration.serde.DynamicNodeDecodingGeneratorStrategy
 import software.amazon.smithy.swift.codegen.integration.serde.UnionDecodeGeneratorStrategy
@@ -452,6 +454,9 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
     override fun initializeMiddleware(ctx: ProtocolGenerator.GenerationContext) {
         for (operation in getHttpBindingOperations(ctx)) {
             operationMiddleware.appendMiddleware(operation, LoggingMiddleware())
+            operationMiddleware.appendMiddleware(operation, ContentLengthMiddleware())
+            operationMiddleware.appendMiddleware(operation, DeserializeMiddleware())
+
             addProtocolSpecificMiddleware(ctx, operation)
 
             for (integration in ctx.integrations) {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/ContentLengthMiddleware.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/ContentLengthMiddleware.kt
@@ -1,0 +1,29 @@
+package software.amazon.smithy.swift.codegen.integration.middlewares
+
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
+import software.amazon.smithy.swift.codegen.SwiftWriter
+import software.amazon.smithy.swift.codegen.integration.OperationMiddlewareRenderable
+import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
+import software.amazon.smithy.swift.codegen.middleware.MiddlewarePosition
+import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
+
+class ContentLengthMiddleware : OperationMiddlewareRenderable {
+
+    override val name = "ContentLengthMiddleware"
+
+    override val middlewareStep = MiddlewareStep.FINALIZESTEP
+
+    override val position = MiddlewarePosition.BEFORE
+
+    override fun render(
+        ctx: ProtocolGenerator.GenerationContext,
+        writer: SwiftWriter,
+        serviceShape: ServiceShape,
+        op: OperationShape,
+        operationStackName: String
+    ) {
+        writer.write("$operationStackName.${middlewareStep.stringValue()}.intercept(position: ${position.stringValue()}, middleware: \$N())", ClientRuntimeTypes.Middleware.ContentLengthMiddleware)
+    }
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/ContentLengthMiddleware.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/ContentLengthMiddleware.kt
@@ -4,12 +4,12 @@ import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
 import software.amazon.smithy.swift.codegen.SwiftWriter
-import software.amazon.smithy.swift.codegen.integration.OperationMiddlewareRenderable
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.middleware.MiddlewarePosition
+import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderable
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 
-class ContentLengthMiddleware : OperationMiddlewareRenderable {
+class ContentLengthMiddleware : MiddlewareRenderable {
 
     override val name = "ContentLengthMiddleware"
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/DeserializeMiddleware.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/DeserializeMiddleware.kt
@@ -4,12 +4,12 @@ import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
 import software.amazon.smithy.swift.codegen.SwiftWriter
-import software.amazon.smithy.swift.codegen.integration.OperationMiddlewareRenderable
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.middleware.MiddlewarePosition
+import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderable
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 
-class DeserializeMiddleware : OperationMiddlewareRenderable {
+class DeserializeMiddleware : MiddlewareRenderable {
 
     override val name = "DeserializeMiddleware"
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/DeserializeMiddleware.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/DeserializeMiddleware.kt
@@ -1,0 +1,29 @@
+package software.amazon.smithy.swift.codegen.integration.middlewares
+
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
+import software.amazon.smithy.swift.codegen.SwiftWriter
+import software.amazon.smithy.swift.codegen.integration.OperationMiddlewareRenderable
+import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
+import software.amazon.smithy.swift.codegen.middleware.MiddlewarePosition
+import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
+
+class DeserializeMiddleware : OperationMiddlewareRenderable {
+
+    override val name = "DeserializeMiddleware"
+
+    override val middlewareStep = MiddlewareStep.DESERIALIZESTEP
+
+    override val position = MiddlewarePosition.AFTER
+
+    override fun render(
+        ctx: ProtocolGenerator.GenerationContext,
+        writer: SwiftWriter,
+        serviceShape: ServiceShape,
+        op: OperationShape,
+        operationStackName: String
+    ) {
+        writer.write("$operationStackName.${middlewareStep.stringValue()}.intercept(position: ${position.stringValue()}, middleware: \$N())", ClientRuntimeTypes.Middleware.DeserializeMiddleware)
+    }
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/middleware/MiddlewareExecutionGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/middleware/MiddlewareExecutionGenerator.kt
@@ -127,7 +127,6 @@ class MiddlewareExecutionGenerator(
     }
 
     private fun renderMiddlewares(op: OperationShape, operationStackName: String) {
-        writer.write("$operationStackName.addDefaultOperationMiddlewares()")
         val inputShape = model.expectShape(op.input.get())
         val inputShapeName = symbolProvider.toSymbol(inputShape).name
         val outputShape = model.expectShape(op.output.get())

--- a/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
@@ -164,7 +164,6 @@ class HttpProtocolClientGeneratorTests {
                               .withIdempotencyTokenGenerator(value: config.idempotencyTokenGenerator)
                               .withLogger(value: config.logger)
                 var operation = ClientRuntime.OperationStack<AllocateWidgetInput, AllocateWidgetOutputResponse, AllocateWidgetOutputError>(id: "allocateWidget")
-                operation.addDefaultOperationMiddlewares()
                 operation.initializeStep.intercept(position: .before, id: "IdempotencyTokenMiddleware") { (context, input, next) -> Swift.Result<ClientRuntime.OperationOutput<AllocateWidgetOutputResponse>, ClientRuntime.SdkError<AllocateWidgetOutputError>> in
                     let idempotencyTokenGenerator = context.getIdempotencyTokenGenerator()
                     var copiedInput = input
@@ -177,7 +176,9 @@ class HttpProtocolClientGeneratorTests {
                 operation.serializeStep.intercept(position: .before, middleware: AllocateWidgetInputQueryItemMiddleware())
                 operation.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<AllocateWidgetInput, AllocateWidgetOutputResponse, AllocateWidgetOutputError>(contentType: "application/json"))
                 operation.serializeStep.intercept(position: .before, middleware: AllocateWidgetInputBodyMiddleware())
+                operation.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
                 operation.deserializeStep.intercept(position: .before, middleware: ClientRuntime.LoggerMiddleware(clientLogMode: config.clientLogMode))
+                operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware())
                 let result = operation.handleMiddleware(context: context.build(), input: input, next: client.getHandler())
                 completion(result)
             }


### PR DESCRIPTION
Removing addDefaultOperationMiddlewares
corresponding: https://github.com/awslabs/aws-sdk-swift/pull/394
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.