### PR TITLE
chore: fix contentmd5middleware to render properly

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/ContentMD5Middleware.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/ContentMD5Middleware.kt
@@ -1,10 +1,12 @@
 package software.amazon.smithy.swift.codegen.integration.middlewares
 
 import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.traits.HttpChecksumRequiredTrait
 import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
 import software.amazon.smithy.swift.codegen.ServiceGenerator
 import software.amazon.smithy.swift.codegen.SwiftWriter
+import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.middleware.MiddlewarePosition
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderable
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
@@ -17,6 +19,15 @@ class ContentMD5Middleware : MiddlewareRenderable {
 
     override val position = MiddlewarePosition.BEFORE
 
+    override fun render(ctx: ProtocolGenerator.GenerationContext, writer: SwiftWriter, serviceShape: ServiceShape, op: OperationShape, operationStackName: String) {
+        if (op.hasTrait<HttpChecksumRequiredTrait>()) {
+            val outputShapeName = ServiceGenerator.getOperationOutputShapeName(ctx.symbolProvider, ctx.model, op)
+            val outputErrorName = ServiceGenerator.getOperationErrorShapeName(op)
+            writer.write("$operationStackName.${middlewareStep.stringValue()}.intercept(position: ${position.stringValue()}, middleware: \$N<$outputShapeName, $outputErrorName>())", ClientRuntimeTypes.Middleware.ContentMD5Middleware)
+        }
+    }
+
+    // TODO: Remove this so that there is only one render function
     fun render(
         op: OperationShape,
         writer: SwiftWriter,

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/middleware/MiddlewareRenderable.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/middleware/MiddlewareRenderable.kt
@@ -22,7 +22,7 @@ interface MiddlewareRenderable {
 
     val position: MiddlewarePosition
 
-    fun render(ctx: ProtocolGenerator.GenerationContext, writer: SwiftWriter, serviceShape: ServiceShape, op: OperationShape, operationStackName: String) {}
+    fun render(ctx: ProtocolGenerator.GenerationContext, writer: SwiftWriter, serviceShape: ServiceShape, op: OperationShape, operationStackName: String)
 
     fun middlewareParamsString(ctx: ProtocolGenerator.GenerationContext, serviceShape: ServiceShape, op: OperationShape): String { return "" }
 }

--- a/smithy-swift-codegen/src/test/kotlin/ContentMd5MiddlewareTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/ContentMd5MiddlewareTests.kt
@@ -1,0 +1,56 @@
+import io.kotest.matchers.string.shouldContainOnlyOnce
+import org.junit.jupiter.api.Test
+
+class ContentMd5MiddlewareTests {
+    @Test
+    fun `generates ContentMD5 middleware`() {
+        val context = setupTests("Isolated/contentmd5checksum.smithy", "aws.protocoltests.restxml#RestXml")
+        val contents = getFileContents(context.manifest, "/RestXml/RestXmlProtocolClient.swift")
+        val expectedContents =
+            """
+            extension RestXmlProtocolClient: RestXmlProtocolClientProtocol {
+                public func idempotencyTokenWithStructure(input: IdempotencyTokenWithStructureInput, completion: @escaping (ClientRuntime.SdkResult<IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>) -> Void)
+                {
+                    let urlPath = "/IdempotencyTokenWithStructure"
+                    let context = ClientRuntime.HttpContextBuilder()
+                                  .withEncoder(value: encoder)
+                                  .withDecoder(value: decoder)
+                                  .withMethod(value: .put)
+                                  .withPath(value: urlPath)
+                                  .withServiceName(value: serviceName)
+                                  .withOperation(value: "idempotencyTokenWithStructure")
+                                  .withIdempotencyTokenGenerator(value: config.idempotencyTokenGenerator)
+                                  .withLogger(value: config.logger)
+                    var operation = ClientRuntime.OperationStack<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>(id: "idempotencyTokenWithStructure")
+                    operation.initializeStep.intercept(position: .before, id: "IdempotencyTokenMiddleware") { (context, input, next) -> Swift.Result<ClientRuntime.OperationOutput<IdempotencyTokenWithStructureOutputResponse>, ClientRuntime.SdkError<IdempotencyTokenWithStructureOutputError>> in
+                        let idempotencyTokenGenerator = context.getIdempotencyTokenGenerator()
+                        var copiedInput = input
+                        if input.token == nil {
+                            copiedInput.token = idempotencyTokenGenerator.generateToken()
+                        }
+                        return next.handle(context: context, input: copiedInput)
+                    }
+                    operation.buildStep.intercept(position: .before, middleware: ClientRuntime.ContentMD5Middleware<IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>())
+                    operation.serializeStep.intercept(position: .after, middleware: IdempotencyTokenWithStructureInputHeadersMiddleware())
+                    operation.serializeStep.intercept(position: .after, middleware: IdempotencyTokenWithStructureInputQueryItemMiddleware())
+                    operation.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>(contentType: "application/xml"))
+                    operation.serializeStep.intercept(position: .after, middleware: IdempotencyTokenWithStructureInputBodyMiddleware())
+                    operation.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
+                    operation.deserializeStep.intercept(position: .before, middleware: ClientRuntime.LoggerMiddleware(clientLogMode: config.clientLogMode))
+                    operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware())
+                    let result = operation.handleMiddleware(context: context.build(), input: input, next: client.getHandler())
+                    completion(result)
+                }
+            """.trimIndent()
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
+    private fun setupTests(smithyFile: String, serviceShapeId: String): TestContext {
+        val context = TestContext.initContextFrom(smithyFile, serviceShapeId, MockHttpRestXMLProtocolGenerator()) { model ->
+            model.defaultSettings(serviceShapeId, "RestXml", "2019-12-16", "Rest Xml Protocol")
+        }
+        context.generator.initializeMiddleware(context.generationCtx)
+        context.generator.generateProtocolClient(context.generationCtx)
+        context.generationCtx.delegator.flushWriters()
+        return context
+    }
+}

--- a/smithy-swift-codegen/src/test/resources/Isolated/contentmd5checksum.smithy
+++ b/smithy-swift-codegen/src/test/resources/Isolated/contentmd5checksum.smithy
@@ -1,0 +1,27 @@
+
+$version: "1.0"
+
+namespace aws.protocoltests.restxml
+
+use aws.api#service
+use aws.protocols#restXml
+
+@service(sdkId: "Rest Xml Protocol")
+@restXml
+service RestXml {
+    version: "2019-12-16",
+    operations: [
+        IdempotencyTokenWithStructure
+    ]
+}
+
+@httpChecksumRequired
+@http(uri: "/IdempotencyTokenWithStructure", method: "PUT")
+operation IdempotencyTokenWithStructure {
+    input: IdempotencyToken,
+}
+
+structure IdempotencyToken {
+    @idempotencyToken
+    token: String,
+}


### PR DESCRIPTION
ContentMD5Middleware was not properly conforming to `MiddlewareRenderable` (well, it was but.. since there was a default impl  of `{}`, it was possible to call render on this middleware and render nothing) -- therefore in real code generated client, the ContentMD5Middleware was never getting properly rendered

This is a temporary fix before we revamp the interface.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.