### PR TITLE
fix: Prefix build targets in package manifest

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
@@ -24,21 +24,21 @@ fun writePackageManifest(settings: SwiftSettings, fileManifest: FileManifest, de
     writer.write("import PackageDescription")
     writer.write("import class Foundation.ProcessInfo")
     writer.write("import class Foundation.FileManager")
-
+    val prefixedTargetName = "AWS${settings.moduleName}"
     writer.openBlock("let package = Package(", ")") {
-        writer.write("name: \"${settings.moduleName}\",")
+        writer.write("name: \"${prefixedTargetName}\",")
 
         writer.openBlock("platforms: [", "],") {
             writer.write(".macOS(.v10_15), .iOS(.v13)")
         }
 
         writer.openBlock("products: [", "],") {
-            writer.write(".library(name: \"${settings.moduleName}\", targets: [\"${settings.moduleName}\"])")
+            writer.write(".library(name: \"${prefixedTargetName}\", targets: [\"${prefixedTargetName}\"])")
         }
 
         writer.openBlock("targets: [", "]") {
             writer.openBlock(".target(", "),") {
-                writer.write("name: \"${settings.moduleName}\",")
+                writer.write("name: \"${prefixedTargetName}\",")
                 writer.openBlock("dependencies: [", "],") {
                     for (dependency in distinctDependencies) {
                         writer.openBlock(".product(", "),") {
@@ -52,9 +52,9 @@ fun writePackageManifest(settings: SwiftSettings, fileManifest: FileManifest, de
             }
             if (generateTestTarget) {
                 writer.openBlock(".testTarget(", ")") {
-                    writer.write("name: \"${settings.moduleName}Tests\",")
+                    writer.write("name: \"${prefixedTargetName}Tests\",")
                     writer.openBlock("dependencies: [", "],") {
-                        writer.write("\$S,", settings.moduleName)
+                        writer.write("\$S,", prefixedTargetName)
                         writer.write(".product(name: \"SmithyTestUtil\", package: \"ClientRuntime\")")
                     }
                     writer.write("path: \"./${settings.moduleName}Tests\"")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
This resolves a naming conflict issue Amplify was having with SPM.


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.