### PR TITLE
fix: date time to use fractional seconds

### DIFF
--- a/Packages/ClientRuntime/Sources/Serialization/SerializationUtils/TimestampWrapperDecoder.swift
+++ b/Packages/ClientRuntime/Sources/Serialization/SerializationUtils/TimestampWrapperDecoder.swift
@@ -11,14 +11,21 @@ public struct TimestampWrapperDecoder {
     static public func parseDateStringValue(_ dateStringValue: String,
                                             format: TimestampFormat,
                                             codingPath: [CodingKey]? = nil) throws -> Date {
-        let formatter: DateFormatter?
+        var formatter: DateFormatter?
         switch format {
         case .epochSeconds:
             return Date(timeIntervalSince1970: TimeInterval(dateStringValue)!)
         case .dateTime:
-            formatter = DateFormatter.iso8601DateFormatterWithFractionalSeconds
+            formatter = DateFormatter.iso8601DateFormatterWithoutFractionalSeconds
+            if let formattedDate = formatter!.date(from: dateStringValue) {
+                return formattedDate
+            } else {
+                formatter = DateFormatter.iso8601DateFormatterWithFractionalSeconds
+            }
+
         case .httpDate:
             formatter = DateFormatter.rfc5322DateFormatter
+
         }
         
         guard let formattedDate = formatter!.date(from: dateStringValue) else {
@@ -27,5 +34,6 @@ public struct TimestampWrapperDecoder {
             throw DecodingError.dataCorrupted(context)
         }
         return formattedDate
+
     }
 }

--- a/Packages/ClientRuntime/Sources/Serialization/SerializationUtils/TimestampWrapperDecoder.swift
+++ b/Packages/ClientRuntime/Sources/Serialization/SerializationUtils/TimestampWrapperDecoder.swift
@@ -16,7 +16,7 @@ public struct TimestampWrapperDecoder {
         case .epochSeconds:
             return Date(timeIntervalSince1970: TimeInterval(dateStringValue)!)
         case .dateTime:
-            formatter = DateFormatter.iso8601DateFormatterWithoutFractionalSeconds
+            formatter = DateFormatter.iso8601DateFormatterWithFractionalSeconds
         case .httpDate:
             formatter = DateFormatter.rfc5322DateFormatter
         }

--- a/Packages/ClientRuntime/Sources/Serialization/SerializationUtils/TimestampWrapperDecoder.swift
+++ b/Packages/ClientRuntime/Sources/Serialization/SerializationUtils/TimestampWrapperDecoder.swift
@@ -11,29 +11,26 @@ public struct TimestampWrapperDecoder {
     static public func parseDateStringValue(_ dateStringValue: String,
                                             format: TimestampFormat,
                                             codingPath: [CodingKey]? = nil) throws -> Date {
-        var formatter: DateFormatter?
+        var formattedDate: Date?
+
         switch format {
         case .epochSeconds:
-            return Date(timeIntervalSince1970: TimeInterval(dateStringValue)!)
+            formattedDate = Date(timeIntervalSince1970: TimeInterval(dateStringValue)!)
         case .dateTime:
-            formatter = DateFormatter.iso8601DateFormatterWithoutFractionalSeconds
-            if let formattedDate = formatter!.date(from: dateStringValue) {
-                return formattedDate
-            } else {
-                formatter = DateFormatter.iso8601DateFormatterWithFractionalSeconds
+            if let date = DateFormatter.iso8601DateFormatterWithoutFractionalSeconds.date(from: dateStringValue) {
+                formattedDate = date
+            } else if let date = DateFormatter.iso8601DateFormatterWithFractionalSeconds.date(from: dateStringValue) {
+                formattedDate = date
             }
-
         case .httpDate:
-            formatter = DateFormatter.rfc5322DateFormatter
-
+            formattedDate = DateFormatter.rfc5322DateFormatter.date(from: dateStringValue)
         }
-        
-        guard let formattedDate = formatter!.date(from: dateStringValue) else {
+
+        guard let formattedDate = formattedDate else {
             let context = DecodingError.Context(codingPath: codingPath ?? [],
                                                 debugDescription: "Unable to parse: \(dateStringValue) to format \(format)")
             throw DecodingError.dataCorrupted(context)
         }
         return formattedDate
-
-    }
+    }    
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
This closes https://github.com/awslabs/aws-sdk-swift/issues/390
## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Rest xml uses date time format with fractional seconds

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.