### PR TITLE
fix: test change needed to pass an import down to smithy swift

### DIFF
--- a/Packages/ClientRuntime/Sources/PrimitiveTypeExtensions/Number+Extension.swift
+++ b/Packages/ClientRuntime/Sources/PrimitiveTypeExtensions/Number+Extension.swift
@@ -28,4 +28,3 @@ public extension Double {
         }
     }
 }
-

--- a/Packages/SmithyTestUtil/Sources/RequestTestUtil/MockSerializeStreamMiddleware.swift
+++ b/Packages/SmithyTestUtil/Sources/RequestTestUtil/MockSerializeStreamMiddleware.swift
@@ -8,7 +8,13 @@
 import ClientRuntime
 
 public struct MockSerializeStreamMiddleware: Middleware {
-    public func handle<H>(context: HttpContext, input: SerializeStepInput<MockStreamInput>, next: H) -> Result<OperationOutput<MockOutput>, SdkError<MockMiddlewareError>> where H: Handler, HttpContext == H.Context, SdkError<MockMiddlewareError> == H.MiddlewareError, SerializeStepInput<MockStreamInput> == H.Input, OperationOutput<MockOutput> == H.Output {
+    public func handle<H>(context: HttpContext,
+                          input: SerializeStepInput<MockStreamInput>,
+                          next: H) -> Result<OperationOutput<MockOutput>, SdkError<MockMiddlewareError>>
+    where H: Handler, HttpContext == H.Context,
+          SdkError<MockMiddlewareError> == H.MiddlewareError,
+          SerializeStepInput<MockStreamInput> == H.Input,
+          OperationOutput<MockOutput> == H.Output {
         input.builder.withBody(HttpBody.stream(input.operationInput.body))
         return next.handle(context: context, input: input)
     }

--- a/Packages/SmithyTestUtil/Sources/RequestTestUtil/MockSerializeStreamMiddleware.swift
+++ b/Packages/SmithyTestUtil/Sources/RequestTestUtil/MockSerializeStreamMiddleware.swift
@@ -1,0 +1,27 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+   
+import ClientRuntime
+
+public struct MockSerializeStreamMiddleware: Middleware {
+    public func handle<H>(context: HttpContext, input: SerializeStepInput<MockStreamInput>, next: H) -> Result<OperationOutput<MockOutput>, SdkError<MockMiddlewareError>> where H : Handler, HttpContext == H.Context, SdkError<MockMiddlewareError> == H.MiddlewareError, SerializeStepInput<MockStreamInput> == H.Input, OperationOutput<MockOutput> == H.Output {
+        input.builder.withBody(HttpBody.stream(input.operationInput.body))
+        return next.handle(context: context, input: input)
+    }
+    
+    public init() {}
+    
+    public var id: String = "MockSerializeStreamMiddleware"
+    
+    public typealias MInput = SerializeStepInput<MockStreamInput>
+    
+    public typealias MOutput = OperationOutput<MockOutput>
+    
+    public typealias Context = HttpContext
+    
+    public typealias MError = SdkError<MockMiddlewareError>
+}

--- a/Packages/SmithyTestUtil/Sources/RequestTestUtil/MockSerializeStreamMiddleware.swift
+++ b/Packages/SmithyTestUtil/Sources/RequestTestUtil/MockSerializeStreamMiddleware.swift
@@ -8,7 +8,7 @@
 import ClientRuntime
 
 public struct MockSerializeStreamMiddleware: Middleware {
-    public func handle<H>(context: HttpContext, input: SerializeStepInput<MockStreamInput>, next: H) -> Result<OperationOutput<MockOutput>, SdkError<MockMiddlewareError>> where H : Handler, HttpContext == H.Context, SdkError<MockMiddlewareError> == H.MiddlewareError, SerializeStepInput<MockStreamInput> == H.Input, OperationOutput<MockOutput> == H.Output {
+    public func handle<H>(context: HttpContext, input: SerializeStepInput<MockStreamInput>, next: H) -> Result<OperationOutput<MockOutput>, SdkError<MockMiddlewareError>> where H: Handler, HttpContext == H.Context, SdkError<MockMiddlewareError> == H.MiddlewareError, SerializeStepInput<MockStreamInput> == H.Input, OperationOutput<MockOutput> == H.Output {
         input.builder.withBody(HttpBody.stream(input.operationInput.body))
         return next.handle(context: context, input: input)
     }

--- a/Packages/SmithyTestUtil/Sources/RequestTestUtil/MockStreamInput.swift
+++ b/Packages/SmithyTestUtil/Sources/RequestTestUtil/MockStreamInput.swift
@@ -1,0 +1,15 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+import ClientRuntime
+
+public struct MockStreamInput: Reflection, Encodable {
+    let body: ByteStream
+    
+    public init(body: ByteStream) {
+        self.body = body
+    }
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolTestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolTestGenerator.kt
@@ -89,7 +89,7 @@ class HttpProtocolTestGenerator(
             val testFilename = "./${ctx.settings.moduleName}Tests/$testClassName.swift"
             ctx.delegator.useTestFileWriter(testFilename, ctx.settings.moduleName) { writer ->
                 LOGGER.fine("Generating request protocol test cases for ${operation.id}")
-                for( import in imports) {
+                for (import in imports) {
                     writer.addImport(import)
                 }
                 writer.addImport(SwiftDependency.CLIENT_RUNTIME.target)

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolTestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolTestGenerator.kt
@@ -34,6 +34,7 @@ class HttpProtocolTestGenerator(
     private val httpProtocolCustomizable: HttpProtocolCustomizable,
     private val operationMiddleware: OperationMiddleware,
     private val serdeContext: HttpProtocolUnitTestGenerator.SerdeContext,
+    private val imports: List<String> = listOf(),
     // list of test IDs to ignore/skip
     private val testsToIgnore: Set<String> = setOf()
 ) {
@@ -88,7 +89,9 @@ class HttpProtocolTestGenerator(
             val testFilename = "./${ctx.settings.moduleName}Tests/$testClassName.swift"
             ctx.delegator.useTestFileWriter(testFilename, ctx.settings.moduleName) { writer ->
                 LOGGER.fine("Generating request protocol test cases for ${operation.id}")
-
+                for( import in imports) {
+                    writer.addImport(import)
+                }
                 writer.addImport(SwiftDependency.CLIENT_RUNTIME.target)
                 writer.addImport(ctx.settings.moduleName, true)
                 writer.addImport(SwiftDependency.SMITHY_TEST_UTIL.target)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Corresponding PRs: https://github.com/awslabs/aws-crt-swift/pull/46 and https://github.com/awslabs/aws-sdk-swift/pull/421



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.