### PR TITLE
fix: tcp connection timeout

### DIFF
--- a/Packages/ClientRuntime/Sources/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/CRT/CRTClientEngine.swift
@@ -37,7 +37,10 @@ public class CRTClientEngine: HttpClientEngine {
             logger.error("Server name was not able to be set in TLS Connection Options. TLS Negotiation will fail.")
             logger.error("Error: \(err.localizedDescription)")
         }
-        let socketOptions = SocketOptions(socketType: .stream)
+        var socketOptions = SocketOptions(socketType: .stream)
+#if os(iOS) || os(watchOS)
+        socketOptions.connectTimeoutMs = 30_000
+#endif
         let options = HttpClientConnectionOptions(clientBootstrap: SDKDefaultIO.shared.clientBootstrap,
                                                   hostName: endpoint.host,
                                                   initialWindowSize: windowSize,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This fixes the tcp timeout for iOS/watchOS per the new SEP requirements. Corresponding PR: https://github.com/awslabs/aws-crt-swift/pull/56

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.