### PR TITLE
fix: Fixes an issue with creation of crt Logger

### DIFF
--- a/Packages/ClientRuntime/Sources/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/CRT/CRTClientEngine.swift
@@ -13,7 +13,6 @@ import AwsCommonRuntimeKit
 public class CRTClientEngine: HttpClientEngine {
     
     private var logger: LogAgent
-    private var crtLogger: Logger
     private var connectionPools: [Endpoint: HttpClientConnectionManager] = [:]
     private let CONTENT_LENGTH_HEADER = "Content-Length"
     private let AWS_COMMON_RUNTIME = "AwsCommonRuntime"
@@ -27,7 +26,6 @@ public class CRTClientEngine: HttpClientEngine {
         self.maxConnectionsPerEndpoint = config.maxConnectionsPerEndpoint
         self.windowSize = config.windowSize
         self.logger = SwiftLogger(label: "CRTClientEngine")
-        self.crtLogger = Logger(pipe: stdout, level: .none, allocator: defaultAllocator)
     }
     
     private func createConnectionPool(endpoint: Endpoint) -> HttpClientConnectionManager {

--- a/Packages/ClientRuntime/Sources/Networking/Http/CRT/SDKDefaultIO.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/CRT/SDKDefaultIO.swift
@@ -14,7 +14,7 @@ import Darwin
 #endif
 
 public final class SDKDefaultIO {
-    static weak var privateShared: SDKDefaultIO? = nil
+    static weak var privateShared: SDKDefaultIO?
     
     // TODO: revisit this and verify that it is thread safe.
     public static var shared: SDKDefaultIO {

--- a/Packages/ClientRuntime/Sources/Networking/Http/CRT/SDKDefaultIO.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/CRT/SDKDefaultIO.swift
@@ -7,6 +7,11 @@
 	
 import AwsCommonRuntimeKit
 import class Foundation.ProcessInfo
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
 
 public final class SDKDefaultIO {
     static weak var privateShared: SDKDefaultIO? = nil
@@ -26,9 +31,11 @@ public final class SDKDefaultIO {
     public var hostResolver: DefaultHostResolver
     public var clientBootstrap: ClientBootstrap
     public var tlsContext: TlsContext
+    public var logger: Logger
 
     private init() {
         AwsCommonRuntimeKit.initialize()
+        self.logger = Logger(pipe: stdout, level: .none, allocator: defaultAllocator)
         self.eventLoopGroup = EventLoopGroup(threadCount: 0)
         self.hostResolver = DefaultHostResolver(eventLoopGroup: eventLoopGroup,
                                                 maxHosts: 8,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
This corrects an issue @royjit found where one thread was creating the logger and another was creating the event loop in the crt and trying to call the logger before it had been created (race condition). the same thread should be creating both resources so the logger should be moved into the shared io file to be created there with all other crt types.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.