### PR TITLE
fix: fixes s3 decode compiler errors

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeDecodeXMLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeDecodeXMLGenerator.kt
@@ -293,14 +293,14 @@ abstract class MemberShapeDecodeXMLGenerator(
         renderAssigningDecodedMember(memberName, "$value")
     }
 
-    fun renderScalarMember(member: MemberShape, memberTarget: Shape, containerName: String, unkeyed: Boolean = false) {
+    fun renderScalarMember(member: MemberShape, memberTarget: Shape, containerName: String, unkeyed: Boolean = false, isUnion: Boolean = false) {
         val memberName = ctx.symbolProvider.toMemberName(member)
         val memberNameUnquoted = memberName.removeSurrounding("`", "`")
         var memberTargetSymbol = ctx.symbolProvider.toSymbol(memberTarget)
         if (member.hasTrait(SwiftBoxTrait::class.java)) {
             memberTargetSymbol = memberTargetSymbol.recursiveSymbol()
         }
-        val decodeVerb = if (memberTargetSymbol.isBoxed()) "decodeIfPresent" else "decode"
+        val decodeVerb = if (memberTargetSymbol.isBoxed() && !isUnion) "decodeIfPresent" else "decode"
         val decodedMemberName = "${memberNameUnquoted}Decoded"
         if (unkeyed) {
             writer.write("let $decodedMemberName = try $containerName.$decodeVerb(\$N.self)", memberTargetSymbol)

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/StructDecodeXMLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/StructDecodeXMLGenerator.kt
@@ -11,13 +11,10 @@ import software.amazon.smithy.model.shapes.MapShape
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.TimestampShape
 import software.amazon.smithy.model.traits.TimestampFormatTrait
-import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
 import software.amazon.smithy.swift.codegen.SwiftTypes
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
-import software.amazon.smithy.swift.codegen.integration.serde.TimeStampFormat.Companion.determineTimestampFormat
 import software.amazon.smithy.swift.codegen.model.ShapeMetadata
-import software.amazon.smithy.swift.codegen.model.isBoxed
 
 open class StructDecodeXMLGenerator(
     private val ctx: ProtocolGenerator.GenerationContext,
@@ -83,8 +80,6 @@ open class StructDecodeXMLGenerator(
         renderAssigningNil(memberName)
         writer.dedent().write("}")
     }
-
-
 
     override fun renderAssigningDecodedMember(memberName: String, decodedMemberName: String, isBoxed: Boolean) {
         writer.write("$memberName = $decodedMemberName")

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/UnionDecodeXMLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/UnionDecodeXMLGenerator.kt
@@ -72,7 +72,6 @@ class UnionDecodeXMLGenerator(
     override fun renderAssigningSymbol(memberName: String, symbol: String) {
         val member = memberName.removeSurroundingBackticks()
         writer.write("self = .$member($symbol)")
-       // writer.write("return")
     }
 
     override fun renderAssigningNil(memberName: String) {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/UnionDecodeXMLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/UnionDecodeXMLGenerator.kt
@@ -35,16 +35,16 @@ class UnionDecodeXMLGenerator(
                     writer.indent()
                     when (memberTarget) {
                         is CollectionShape -> {
-                            renderListMember(member, memberTarget, containerName)
+                            renderListMember(member, memberTarget, containerName, true)
                         }
                         is MapShape -> {
-                            renderMapMember(member, memberTarget, containerName)
+                            renderMapMember(member, memberTarget, containerName, true)
                         }
                         is TimestampShape -> {
-                            renderTimestampMember(member, memberTarget, containerName)
+                            renderTimestampMember(member, memberTarget, containerName, true)
                         }
                         is BlobShape -> {
-                            renderBlobMember(member, memberTarget, containerName)
+                            renderBlobMember(member, memberTarget, containerName, true)
                         }
                         else -> {
                             renderScalarMember(member, memberTarget, containerName, isUnion = true)

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/lang/ReservedWords.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/lang/ReservedWords.kt
@@ -83,6 +83,7 @@ val reservedWords = listOf(
     "optional",
     "override",
     "postfix",
+    "prefix",
     "private",
     "protocol",
     "Protocol",

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/UnionEncodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/UnionEncodeXMLGenerationTests.kt
@@ -65,93 +65,78 @@ class UnionEncodeXMLGenerationTests {
             
                 public init (from decoder: Swift.Decoder) throws {
                     let containerValues = try decoder.container(keyedBy: CodingKeys.self)
-                    let doublevalueDecoded = try containerValues.decodeIfPresent(Swift.Double.self, forKey: .doublevalue)
-                    if let doublevalue = doublevalueDecoded {
-                        self = .doublevalue(doublevalue)
-                        return
-                    }
-                    if containerValues.contains(.datavalue) {
-                        do {
-                            let datavalueDecoded = try containerValues.decodeIfPresent(ClientRuntime.Data.self, forKey: .datavalue)
-                            if let datavalue = datavalueDecoded {
-                                self = .datavalue(datavalue)
-                                return
-                            }
-                        } catch {
-                            if let datavalue = "".data(using: .utf8) {
-                                self = .datavalue(datavalue)
-                                return
-                            }
-                        }
-                    } else {
-                        //No-op
-                    }
-                    let unionvalueDecoded = try containerValues.decodeIfPresent(Box<RestXmlProtocolClientTypes.XmlUnionShape>.self, forKey: .unionvalue)
-                    if let unionvalue = unionvalueDecoded {
-                        self = .unionvalue(unionvalue.value)
-                        return
-                    }
-                    let structvalueDecoded = try containerValues.decodeIfPresent(RestXmlProtocolClientTypes.XmlNestedUnionStruct.self, forKey: .structvalue)
-                    if let structvalue = structvalueDecoded {
-                        self = .structvalue(structvalue)
-                        return
-                    }
-                    if containerValues.contains(.mapvalue) {
-                        struct KeyVal0{struct K{}; struct V{}}
-                        let mapvalueWrappedContainer = containerValues.nestedContainerNonThrowable(keyedBy: ClientRuntime.MapEntry<Swift.String, Swift.String, KeyVal0.K, KeyVal0.V>.CodingKeys.self, forKey: .mapvalue)
-                        if let mapvalueWrappedContainer = mapvalueWrappedContainer {
-                            let mapvalueContainer = try mapvalueWrappedContainer.decodeIfPresent([ClientRuntime.MapKeyValue<Swift.String, Swift.String, KeyVal0.K, KeyVal0.V>].self, forKey: .entry)
-                            var mapvalueBuffer: [Swift.String:Swift.String]? = nil
-                            if let mapvalueContainer = mapvalueContainer {
-                                mapvalueBuffer = [Swift.String:Swift.String]()
-                                for stringContainer0 in mapvalueContainer {
-                                    mapvalueBuffer?[stringContainer0.key] = stringContainer0.value
+                    let key = containerValues.allKeys.first
+                    switch key {
+                        case .doublevalue:
+                            let doublevalueDecoded = try containerValues.decode(Swift.Double.self, forKey: .doublevalue)
+                            self = .doublevalue(doublevalueDecoded)
+                        case .datavalue:
+                            if containerValues.contains(.datavalue) {
+                                do {
+                                    let datavalueDecoded = try containerValues.decodeIfPresent(ClientRuntime.Data.self, forKey: .datavalue)
+                                    self = .datavalue(datavalueDecoded)
+                                } catch {
+                                    self = .datavalue("".data(using: .utf8))
                                 }
+                            } else {
+                                //No-op
                             }
-                            if let mapvalue = mapvalueBuffer {
-                                self = .mapvalue(mapvalue)
-                                return
-                            }
-                        } else {
-                            self = .mapvalue([:])
-                            return
-                        }
-                    } else {
-                        //No-op
-                    }
-                    if containerValues.contains(.stringlist) {
-                        struct KeyVal0{struct member{}}
-                        let stringlistWrappedContainer = containerValues.nestedContainerNonThrowable(keyedBy: CollectionMemberCodingKey<KeyVal0.member>.CodingKeys.self, forKey: .stringlist)
-                        if let stringlistWrappedContainer = stringlistWrappedContainer {
-                            let stringlistContainer = try stringlistWrappedContainer.decodeIfPresent([Swift.String].self, forKey: .member)
-                            var stringlistBuffer:[Swift.String]? = nil
-                            if let stringlistContainer = stringlistContainer {
-                                stringlistBuffer = [Swift.String]()
-                                for stringContainer0 in stringlistContainer {
-                                    stringlistBuffer?.append(stringContainer0)
+                        case .unionvalue:
+                            let unionvalueDecoded = try containerValues.decode(Box<RestXmlProtocolClientTypes.XmlUnionShape>.self, forKey: .unionvalue)
+                            self = .unionvalue(unionvalueDecoded.value)
+                        case .structvalue:
+                            let structvalueDecoded = try containerValues.decode(RestXmlProtocolClientTypes.XmlNestedUnionStruct.self, forKey: .structvalue)
+                            self = .structvalue(structvalueDecoded)
+                        case .mapvalue:
+                            if containerValues.contains(.mapvalue) {
+                                struct KeyVal0{struct K{}; struct V{}}
+                                let mapvalueWrappedContainer = containerValues.nestedContainerNonThrowable(keyedBy: ClientRuntime.MapEntry<Swift.String, Swift.String, KeyVal0.K, KeyVal0.V>.CodingKeys.self, forKey: .mapvalue)
+                                if let mapvalueWrappedContainer = mapvalueWrappedContainer {
+                                    let mapvalueContainer = try mapvalueWrappedContainer.decodeIfPresent([ClientRuntime.MapKeyValue<Swift.String, Swift.String, KeyVal0.K, KeyVal0.V>].self, forKey: .entry)
+                                    var mapvalueBuffer: [Swift.String:Swift.String]? = nil
+                                    if let mapvalueContainer = mapvalueContainer {
+                                        mapvalueBuffer = [Swift.String:Swift.String]()
+                                        for stringContainer0 in mapvalueContainer {
+                                            mapvalueBuffer?[stringContainer0.key] = stringContainer0.value
+                                        }
+                                    }
+                                    self = .mapvalue(mapvalueBuffer)
+                                } else {
+                                    self = .mapvalue([:])
                                 }
+                            } else {
+                                //No-op
                             }
-                            if let stringlist = stringlistBuffer {
-                                self = .stringlist(stringlist)
-                                return
+                        case .stringlist:
+                            if containerValues.contains(.stringlist) {
+                                struct KeyVal0{struct member{}}
+                                let stringlistWrappedContainer = containerValues.nestedContainerNonThrowable(keyedBy: CollectionMemberCodingKey<KeyVal0.member>.CodingKeys.self, forKey: .stringlist)
+                                if let stringlistWrappedContainer = stringlistWrappedContainer {
+                                    let stringlistContainer = try stringlistWrappedContainer.decodeIfPresent([Swift.String].self, forKey: .member)
+                                    var stringlistBuffer:[Swift.String]? = nil
+                                    if let stringlistContainer = stringlistContainer {
+                                        stringlistBuffer = [Swift.String]()
+                                        for stringContainer0 in stringlistContainer {
+                                            stringlistBuffer?.append(stringContainer0)
+                                        }
+                                    }
+                                    self = .stringlist(stringlistBuffer)
+                                } else {
+                                    self = .stringlist([])
+                                }
+                            } else {
+                                //No-op
                             }
-                        } else {
-                            self = .stringlist([])
-                            return
-                        }
-                    } else {
-                        //No-op
+                        case .timestampvalue:
+                            let timestampvalueDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .timestampvalue)
+                            var timestampvalueBuffer:ClientRuntime.Date? = nil
+                            if let timestampvalueDecoded = timestampvalueDecoded {
+                                timestampvalueBuffer = try ClientRuntime.TimestampWrapperDecoder.parseDateStringValue(timestampvalueDecoded, format: .dateTime)
+                            }
+                            self = .timestampvalue(timestampvalueBuffer)
+                        default:
+                            self = .sdkUnknown("")
                     }
-                    let timestampvalueDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .timestampvalue)
-                    var timestampvalueBuffer:ClientRuntime.Date? = nil
-                    if let timestampvalueDecoded = timestampvalueDecoded {
-                        timestampvalueBuffer = try ClientRuntime.TimestampWrapperDecoder.parseDateStringValue(timestampvalueDecoded, format: .dateTime)
-                    }
-                    if let timestampvalue = timestampvalueBuffer {
-                        self = .timestampvalue(timestampvalue)
-                        return
-                    }
-                    self = .sdkUnknown("")
                 }
             }
             """.trimIndent()

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/UnionEncodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/UnionEncodeXMLGenerationTests.kt
@@ -71,16 +71,8 @@ class UnionEncodeXMLGenerationTests {
                             let doublevalueDecoded = try containerValues.decode(Swift.Double.self, forKey: .doublevalue)
                             self = .doublevalue(doublevalueDecoded)
                         case .datavalue:
-                            if containerValues.contains(.datavalue) {
-                                do {
-                                    let datavalueDecoded = try containerValues.decodeIfPresent(ClientRuntime.Data.self, forKey: .datavalue)
-                                    self = .datavalue(datavalueDecoded)
-                                } catch {
-                                    self = .datavalue("".data(using: .utf8))
-                                }
-                            } else {
-                                //No-op
-                            }
+                            let datavalueDecoded = try containerValues.decode(ClientRuntime.Data.self, forKey: .datavalue)
+                            self = .datavalue(datavalueDecoded)
                         case .unionvalue:
                             let unionvalueDecoded = try containerValues.decode(Box<RestXmlProtocolClientTypes.XmlUnionShape>.self, forKey: .unionvalue)
                             self = .unionvalue(unionvalueDecoded.value)
@@ -88,51 +80,40 @@ class UnionEncodeXMLGenerationTests {
                             let structvalueDecoded = try containerValues.decode(RestXmlProtocolClientTypes.XmlNestedUnionStruct.self, forKey: .structvalue)
                             self = .structvalue(structvalueDecoded)
                         case .mapvalue:
-                            if containerValues.contains(.mapvalue) {
-                                struct KeyVal0{struct K{}; struct V{}}
-                                let mapvalueWrappedContainer = containerValues.nestedContainerNonThrowable(keyedBy: ClientRuntime.MapEntry<Swift.String, Swift.String, KeyVal0.K, KeyVal0.V>.CodingKeys.self, forKey: .mapvalue)
-                                if let mapvalueWrappedContainer = mapvalueWrappedContainer {
-                                    let mapvalueContainer = try mapvalueWrappedContainer.decodeIfPresent([ClientRuntime.MapKeyValue<Swift.String, Swift.String, KeyVal0.K, KeyVal0.V>].self, forKey: .entry)
-                                    var mapvalueBuffer: [Swift.String:Swift.String]? = nil
-                                    if let mapvalueContainer = mapvalueContainer {
-                                        mapvalueBuffer = [Swift.String:Swift.String]()
-                                        for stringContainer0 in mapvalueContainer {
-                                            mapvalueBuffer?[stringContainer0.key] = stringContainer0.value
-                                        }
+                            struct KeyVal0{struct K{}; struct V{}}
+                            let mapvalueWrappedContainer = containerValues.nestedContainerNonThrowable(keyedBy: ClientRuntime.MapEntry<Swift.String, Swift.String, KeyVal0.K, KeyVal0.V>.CodingKeys.self, forKey: .mapvalue)
+                            if let mapvalueWrappedContainer = mapvalueWrappedContainer {
+                                let mapvalueContainer = try mapvalueWrappedContainer.decodeIfPresent([ClientRuntime.MapKeyValue<Swift.String, Swift.String, KeyVal0.K, KeyVal0.V>].self, forKey: .entry)
+                                var mapvalueBuffer: [Swift.String:Swift.String]? = nil
+                                if let mapvalueContainer = mapvalueContainer {
+                                    mapvalueBuffer = [Swift.String:Swift.String]()
+                                    for stringContainer0 in mapvalueContainer {
+                                        mapvalueBuffer?[stringContainer0.key] = stringContainer0.value
                                     }
-                                    self = .mapvalue(mapvalueBuffer)
-                                } else {
-                                    self = .mapvalue([:])
                                 }
+                                self = .mapvalue(mapvalueBuffer)
                             } else {
-                                //No-op
+                                self = .mapvalue([:])
                             }
                         case .stringlist:
-                            if containerValues.contains(.stringlist) {
-                                struct KeyVal0{struct member{}}
-                                let stringlistWrappedContainer = containerValues.nestedContainerNonThrowable(keyedBy: CollectionMemberCodingKey<KeyVal0.member>.CodingKeys.self, forKey: .stringlist)
-                                if let stringlistWrappedContainer = stringlistWrappedContainer {
-                                    let stringlistContainer = try stringlistWrappedContainer.decodeIfPresent([Swift.String].self, forKey: .member)
-                                    var stringlistBuffer:[Swift.String]? = nil
-                                    if let stringlistContainer = stringlistContainer {
-                                        stringlistBuffer = [Swift.String]()
-                                        for stringContainer0 in stringlistContainer {
-                                            stringlistBuffer?.append(stringContainer0)
-                                        }
+                            struct KeyVal0{struct member{}}
+                            let stringlistWrappedContainer = containerValues.nestedContainerNonThrowable(keyedBy: CollectionMemberCodingKey<KeyVal0.member>.CodingKeys.self, forKey: .stringlist)
+                            if let stringlistWrappedContainer = stringlistWrappedContainer {
+                                let stringlistContainer = try stringlistWrappedContainer.decodeIfPresent([Swift.String].self, forKey: .member)
+                                var stringlistBuffer:[Swift.String]? = nil
+                                if let stringlistContainer = stringlistContainer {
+                                    stringlistBuffer = [Swift.String]()
+                                    for stringContainer0 in stringlistContainer {
+                                        stringlistBuffer?.append(stringContainer0)
                                     }
-                                    self = .stringlist(stringlistBuffer)
-                                } else {
-                                    self = .stringlist([])
                                 }
+                                self = .stringlist(stringlistBuffer)
                             } else {
-                                //No-op
+                                self = .stringlist([])
                             }
                         case .timestampvalue:
-                            let timestampvalueDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .timestampvalue)
-                            var timestampvalueBuffer:ClientRuntime.Date? = nil
-                            if let timestampvalueDecoded = timestampvalueDecoded {
-                                timestampvalueBuffer = try ClientRuntime.TimestampWrapperDecoder.parseDateStringValue(timestampvalueDecoded, format: .dateTime)
-                            }
+                            let timestampvalueDecoded = try containerValues.decode(Swift.String.self, forKey: .timestampvalue)
+                            let timestampvalueBuffer = try ClientRuntime.TimestampWrapperDecoder.parseDateStringValue(timestampvalueDecoded, format: .dateTime)
                             self = .timestampvalue(timestampvalueBuffer)
                         default:
                             self = .sdkUnknown("")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This PR fixes S3 compiler errors with decoding non optional associated values on enums. This additionally changes our decoding of enums with associated values from needing return statemetns everywhere to one switch statement based on the key in the container.

```swift
init(from decoder: Decoder) throws {
    let containerValues = try decoder.container(keyedBy: CodingKeys.self)
    let key = containerValues.allKeys.first
    
    switch key {
    case .empty:
        self = .empty
    case .domain:
        let domain = try container.decode(
            String.self,
            forKey: .editing
        )
        self = .domain(domain)
    case .port:
        let port = try container.decode(
            Int.self,
            forKey: .port
        )
        self = .port(port)
    default:
        self = .sdkUnknown("")
    }
}

```

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.