### PR TITLE
feat: add initialize/cleanup interface for users of clientruntime

### DIFF
--- a/Packages/ClientRuntime/Sources/Networking/ClientRuntime.swift
+++ b/Packages/ClientRuntime/Sources/Networking/ClientRuntime.swift
@@ -18,7 +18,7 @@ public class ClientRuntime {
      this function once and only once, but it should be safe to call this multiple times during
      start up
      */
-    static func initialize() {
+    public static func initialize() {
         AwsCommonRuntimeKit.initialize()
     }
 
@@ -29,7 +29,7 @@ public class ClientRuntime {
      this function once and only once, but it should be safe to call this multiple times during
      start up
      */
-    static func cleanUp() {
+    public static func cleanUp() {
         AwsCommonRuntimeKit.cleanUp()
     }
 }

--- a/Packages/ClientRuntime/Sources/Networking/ClientRuntime.swift
+++ b/Packages/ClientRuntime/Sources/Networking/ClientRuntime.swift
@@ -1,0 +1,35 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+	
+
+import AwsCommonRuntimeKit
+
+public class ClientRuntime {
+    /**
+     Initializes the underlying runtime.  You will need to do call prior to using the functions that call
+     into lower level interfaces... TODO.. FINISH
+     directly (instead of a higher level SDK).
+
+     - Note: It is expected that calling this function is idempotent. Do your best to call
+     this function once and only once, but it should be safe to call this multiple times during
+     start up
+     */
+    static func initialize() {
+        AwsCommonRuntimeKit.initialize()
+    }
+
+    /**
+    TODO:
+
+     - Note: It is expected that calling this function is idempotent. Do your best to call
+     this function once and only once, but it should be safe to call this multiple times during
+     start up
+     */
+    static func cleanUp() {
+        AwsCommonRuntimeKit.cleanUp()
+    }
+}


### PR DESCRIPTION
Seems like we need an interface here, to avoid people calling directly into the CRT.... thoughts on naming?  If we are good with naming, i'll finish up documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.