### PR TITLE
fix: shave off 4 mb from sdks

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/CodegenVisitor.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/CodegenVisitor.kt
@@ -155,7 +155,7 @@ class CodegenVisitor(context: PluginContext) : ShapeVisitor.Default<Void>() {
 
     override fun structureShape(shape: StructureShape): Void? {
         writers.useShapeWriter(shape) { writer: SwiftWriter -> StructureGenerator(model, symbolProvider, writer, shape, settings, protocolGenerator?.serviceErrorProtocolSymbol).render() }
-        if (shape.hasTrait<SensitiveTrait>()) {
+        if (shape.hasTrait<SensitiveTrait>() || shape.members().any { it.hasTrait<SensitiveTrait>() }) {
             writers.useShapeExtensionWriter(shape, "CustomDebugStringConvertible") { writer: SwiftWriter ->
                 CustomDebugStringConvertibleGenerator(symbolProvider, writer, shape).render()
             }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/CodegenVisitor.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/CodegenVisitor.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.model.traits.EnumTrait
+import software.amazon.smithy.model.traits.SensitiveTrait
 import software.amazon.smithy.swift.codegen.core.GenerationContext
 import software.amazon.smithy.swift.codegen.integration.CustomDebugStringConvertibleGenerator
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
@@ -154,8 +155,10 @@ class CodegenVisitor(context: PluginContext) : ShapeVisitor.Default<Void>() {
 
     override fun structureShape(shape: StructureShape): Void? {
         writers.useShapeWriter(shape) { writer: SwiftWriter -> StructureGenerator(model, symbolProvider, writer, shape, settings, protocolGenerator?.serviceErrorProtocolSymbol).render() }
-        writers.useShapeExtensionWriter(shape, "CustomDebugStringConvertible") { writer: SwiftWriter ->
-            CustomDebugStringConvertibleGenerator(symbolProvider, writer, shape).render()
+        if (shape.hasTrait<SensitiveTrait>()) {
+            writers.useShapeExtensionWriter(shape, "CustomDebugStringConvertible") { writer: SwiftWriter ->
+                CustomDebugStringConvertibleGenerator(symbolProvider, writer, shape).render()
+            }
         }
         return null
     }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/StructureGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/StructureGenerator.kt
@@ -126,7 +126,7 @@ class StructureGenerator(
             }
 
             writer.writeAvailableAttribute(model, it)
-            writer.write("public var \$L: \$T", memberName, memberSymbol)
+            writer.write("var \$L: \$T", memberName, memberSymbol)
         }
     }
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpBindingProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpBindingProtocolGenerator.kt
@@ -245,7 +245,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
             writer.openBlock("struct ${decodeSymbol.name}: \$N {", "}", SwiftTypes.Protocols.Equatable) {
                 httpBodyMembers.forEach {
                     val memberSymbol = ctx.symbolProvider.toSymbol(it)
-                    writer.write("public let \$L: \$T", ctx.symbolProvider.toMemberName(it), memberSymbol)
+                    writer.write("let \$L: \$T", ctx.symbolProvider.toMemberName(it), memberSymbol)
                 }
             }
             writer.write("")

--- a/smithy-swift-codegen/src/test/kotlin/HashableShapeTransformerTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HashableShapeTransformerTests.kt
@@ -70,8 +70,8 @@ class HashableShapeTransformerTests {
         Assertions.assertNotNull(hashableShapeInput)
         val expected = """
             public struct HashableShapesInput: Swift.Equatable {
-                public var `set`: Swift.Set<ExampleClientTypes.HashableStructure>?
-                public var bar: Swift.String?
+                var `set`: Swift.Set<ExampleClientTypes.HashableStructure>?
+                var bar: Swift.String?
             
                 public init (
                     `set`: Swift.Set<ExampleClientTypes.HashableStructure>? = nil,
@@ -90,7 +90,7 @@ class HashableShapeTransformerTests {
         Assertions.assertNotNull(hashableShapeOutput)
         val expectedOutput = """
             public struct HashableShapesOutputResponse: Swift.Equatable {
-                public var quz: Swift.String?
+                var quz: Swift.String?
             
                 public init (
                     quz: Swift.String? = nil
@@ -108,8 +108,8 @@ class HashableShapeTransformerTests {
         val expectedStructureShape = """
             extension ExampleClientTypes {
                 public struct HashableStructure: Swift.Equatable, Swift.Hashable {
-                    public var baz: ExampleClientTypes.NestedHashableStructure?
-                    public var foo: Swift.String?
+                    var baz: ExampleClientTypes.NestedHashableStructure?
+                    var foo: Swift.String?
             
                     public init (
                         baz: ExampleClientTypes.NestedHashableStructure? = nil,
@@ -131,8 +131,8 @@ class HashableShapeTransformerTests {
         val expectedNestedStructureShape = """
         extension ExampleClientTypes {
             public struct NestedHashableStructure: Swift.Equatable, Swift.Hashable {
-                public var bar: Swift.String?
-                public var quz: Swift.Int?
+                var bar: Swift.String?
+                var quz: Swift.Int?
         
                 public init (
                     bar: Swift.String? = nil,

--- a/smithy-swift-codegen/src/test/kotlin/RecursiveShapeBoxerTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/RecursiveShapeBoxerTests.kt
@@ -51,7 +51,7 @@ internal class RecursiveShapeBoxerTests {
         val expected =
             """
             public struct RecursiveShapesInput: Swift.Equatable {
-                public var nested: ExampleClientTypes.RecursiveShapesInputOutputNested1?
+                var nested: ExampleClientTypes.RecursiveShapesInputOutputNested1?
             
                 public init (
                     nested: ExampleClientTypes.RecursiveShapesInputOutputNested1? = nil
@@ -69,7 +69,7 @@ internal class RecursiveShapeBoxerTests {
         val expected2 =
             """
             public struct RecursiveShapesOutputResponse: Swift.Equatable {
-                public var nested: ExampleClientTypes.RecursiveShapesInputOutputNested1?
+                var nested: ExampleClientTypes.RecursiveShapesInputOutputNested1?
             
                 public init (
                     nested: ExampleClientTypes.RecursiveShapesInputOutputNested1? = nil
@@ -88,8 +88,8 @@ internal class RecursiveShapeBoxerTests {
             """
             extension ExampleClientTypes {
                 public struct RecursiveShapesInputOutputNested1: Swift.Equatable {
-                    public var foo: Swift.String?
-                    public var nested: Box<ExampleClientTypes.RecursiveShapesInputOutputNested2>?
+                    var foo: Swift.String?
+                    var nested: Box<ExampleClientTypes.RecursiveShapesInputOutputNested2>?
             
                     public init (
                         foo: Swift.String? = nil,
@@ -112,8 +112,8 @@ internal class RecursiveShapeBoxerTests {
             """
         extension ExampleClientTypes {
             public struct RecursiveShapesInputOutputNested2: Swift.Equatable {
-                public var bar: Swift.String?
-                public var recursiveMember: ExampleClientTypes.RecursiveShapesInputOutputNested1?
+                var bar: Swift.String?
+                var recursiveMember: ExampleClientTypes.RecursiveShapesInputOutputNested1?
         
                 public init (
                     bar: Swift.String? = nil,

--- a/smithy-swift-codegen/src/test/kotlin/SensitiveTraitGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/SensitiveTraitGeneratorTests.kt
@@ -42,22 +42,6 @@ class SensitiveTraitGeneratorTests {
     }
 
     @Test
-    fun `NoSensitiveMemberStruct+CustomDebugStringConvertible`() {
-        val manifest = setupTest()
-        var extensionWithSensitiveTrait = manifest
-            .getFileString("example/models/SensitiveTraitTestRequestInput+CustomDebugStringConvertible.swift").get()
-        extensionWithSensitiveTrait.shouldSyntacticSanityCheck()
-        val expectedContents =
-            """
-            extension SensitiveTraitTestRequestInput: Swift.CustomDebugStringConvertible {
-                public var debugDescription: Swift.String {
-                    "SensitiveTraitTestRequestInput(bar: \(Swift.String(describing: bar)), baz: \(Swift.String(describing: baz)), foo: \(Swift.String(describing: foo)))"}
-            }
-            """.trimIndent()
-        extensionWithSensitiveTrait.shouldContainOnlyOnce(expectedContents)
-    }
-
-    @Test
     fun `AllSensitiveMemberStruct+CustomDebugStringConvertible`() {
         val manifest = setupTest()
         var extensionWithSensitiveTrait = manifest

--- a/smithy-swift-codegen/src/test/kotlin/ServiceRenamesTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/ServiceRenamesTests.kt
@@ -22,7 +22,7 @@ class ServiceRenamesTests {
         val expectedContents =
             """
             public struct MyTestOperationInput: Swift.Equatable {
-                public var bar: ExampleClientTypes.RenamedGreeting?
+                var bar: ExampleClientTypes.RenamedGreeting?
             
                 public init (
                     bar: ExampleClientTypes.RenamedGreeting? = nil
@@ -50,7 +50,7 @@ class ServiceRenamesTests {
         val expectedContents =
             """
             public struct MyTestOperationOutputResponse: Swift.Equatable {
-                public var baz: ExampleClientTypes.GreetingStruct?
+                var baz: ExampleClientTypes.GreetingStruct?
             
                 public init (
                     baz: ExampleClientTypes.GreetingStruct? = nil
@@ -79,7 +79,7 @@ class ServiceRenamesTests {
             """
             extension ExampleClientTypes {
                 public struct GreetingStruct: Swift.Equatable {
-                    public var hi: Swift.String?
+                    var hi: Swift.String?
             
                     public init (
                         hi: Swift.String? = nil
@@ -111,7 +111,7 @@ class ServiceRenamesTests {
             """
             extension ExampleClientTypes {
                 public struct RenamedGreeting: Swift.Equatable {
-                    public var salutation: Swift.String?
+                    var salutation: Swift.String?
             
                     public init (
                         salutation: Swift.String? = nil

--- a/smithy-swift-codegen/src/test/kotlin/StructDecodeGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/StructDecodeGenerationTests.kt
@@ -47,9 +47,9 @@ class StructDecodeGenerationTests {
         val expectedContents =
             """
             struct SmokeTestOutputResponseBody: Swift.Equatable {
-                public let payload1: Swift.String?
-                public let payload2: Swift.Int?
-                public let payload3: ExampleClientTypes.Nested?
+                let payload1: Swift.String?
+                let payload2: Swift.Int?
+                let payload3: ExampleClientTypes.Nested?
             }
             
             extension SmokeTestOutputResponseBody: Swift.Decodable {
@@ -170,12 +170,12 @@ class StructDecodeGenerationTests {
         val expectedContents =
             """
 struct TimestampInputOutputResponseBody: Swift.Equatable {
-    public let normal: ClientRuntime.Date?
-    public let dateTime: ClientRuntime.Date?
-    public let epochSeconds: ClientRuntime.Date?
-    public let httpDate: ClientRuntime.Date?
-    public let nestedTimestampList: [[ClientRuntime.Date]]?
-    public let timestampList: [ClientRuntime.Date]?
+    let normal: ClientRuntime.Date?
+    let dateTime: ClientRuntime.Date?
+    let epochSeconds: ClientRuntime.Date?
+    let httpDate: ClientRuntime.Date?
+    let nestedTimestampList: [[ClientRuntime.Date]]?
+    let timestampList: [ClientRuntime.Date]?
 }
 
 extension TimestampInputOutputResponseBody: Swift.Decodable {
@@ -261,12 +261,12 @@ extension TimestampInputOutputResponseBody: Swift.Decodable {
         val expectedContents =
             """
 struct MapInputOutputResponseBody: Swift.Equatable {
-    public let intMap: [Swift.String:Swift.Int]?
-    public let structMap: [Swift.String:ExampleClientTypes.ReachableOnlyThroughMap]?
-    public let enumMap: [Swift.String:ExampleClientTypes.MyEnum]?
-    public let blobMap: [Swift.String:ClientRuntime.Data]?
-    public let nestedMap: [Swift.String:[Swift.String:Swift.Int]]?
-    public let dateMap: [Swift.String:ClientRuntime.Date]?
+    let intMap: [Swift.String:Swift.Int]?
+    let structMap: [Swift.String:ExampleClientTypes.ReachableOnlyThroughMap]?
+    let enumMap: [Swift.String:ExampleClientTypes.MyEnum]?
+    let blobMap: [Swift.String:ClientRuntime.Data]?
+    let nestedMap: [Swift.String:[Swift.String:Swift.Int]]?
+    let dateMap: [Swift.String:ClientRuntime.Date]?
 }
 
 extension MapInputOutputResponseBody: Swift.Decodable {
@@ -370,9 +370,9 @@ extension MapInputOutputResponseBody: Swift.Decodable {
         val expectedContents =
             """
 struct NestedShapesOutputResponseBody: Swift.Equatable {
-    public let nestedListInDict: [Swift.String:[ClientRuntime.Date]]?
-    public let nestedDictInList: [[Swift.String:Swift.String]]?
-    public let nestedListOfListInDict: [Swift.String:[[Swift.Int]]]?
+    let nestedListInDict: [Swift.String:[ClientRuntime.Date]]?
+    let nestedDictInList: [[Swift.String:Swift.String]]?
+    let nestedListOfListInDict: [Swift.String:[[Swift.Int]]]?
 }
 
 extension NestedShapesOutputResponseBody: Swift.Decodable {

--- a/smithy-swift-codegen/src/test/kotlin/StructEncodeGenerationIsolatedTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/StructEncodeGenerationIsolatedTests.kt
@@ -35,8 +35,8 @@ class StructEncodeGenerationIsolatedTests {
         val expectedContents =
             """
             public struct EnumInputInput: Swift.Equatable {
-                public var enumHeader: ExampleClientTypes.MyEnum?
-                public var nestedWithEnum: ExampleClientTypes.NestedEnum?
+                var enumHeader: ExampleClientTypes.MyEnum?
+                var nestedWithEnum: ExampleClientTypes.NestedEnum?
             """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
     }

--- a/smithy-swift-codegen/src/test/kotlin/StructureGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/StructureGeneratorTests.kt
@@ -36,10 +36,10 @@ class StructureGeneratorTests {
             """
             /// This is documentation about the shape.
             public struct MyStruct: Swift.Equatable {
-                public var bar: Swift.Int
+                var bar: Swift.Int
                 /// This is documentation about the member.
-                public var baz: Swift.Int?
-                public var foo: Swift.String?
+                var baz: Swift.Int?
+                var foo: Swift.String?
             
                 public init (
                     bar: Swift.Int = 0,
@@ -69,21 +69,21 @@ class StructureGeneratorTests {
         val expected =
             """
         public struct PrimitiveTypesInput: Swift.Equatable {
-            public var booleanVal: Swift.Bool?
-            public var byteVal: Swift.Int8?
-            public var doubleVal: Swift.Double?
-            public var floatVal: Swift.Float?
-            public var intVal: Swift.Int?
-            public var longVal: Swift.Int?
-            public var primitiveBooleanVal: Swift.Bool
-            public var primitiveByteVal: Swift.Int8
-            public var primitiveDoubleVal: Swift.Double
-            public var primitiveFloatVal: Swift.Float
-            public var primitiveIntVal: Swift.Int
-            public var primitiveLongVal: Swift.Int
-            public var primitiveShortVal: Swift.Int16
-            public var shortVal: Swift.Int16?
-            public var str: Swift.String?
+            var booleanVal: Swift.Bool?
+            var byteVal: Swift.Int8?
+            var doubleVal: Swift.Double?
+            var floatVal: Swift.Float?
+            var intVal: Swift.Int?
+            var longVal: Swift.Int?
+            var primitiveBooleanVal: Swift.Bool
+            var primitiveByteVal: Swift.Int8
+            var primitiveDoubleVal: Swift.Double
+            var primitiveFloatVal: Swift.Float
+            var primitiveIntVal: Swift.Int
+            var primitiveLongVal: Swift.Int
+            var primitiveShortVal: Swift.Int16
+            var shortVal: Swift.Int16?
+            var str: Swift.String?
         
             public init (
                 booleanVal: Swift.Bool? = nil,
@@ -140,8 +140,8 @@ class StructureGeneratorTests {
         val expected =
             """
 public struct RecursiveShapesInputOutputNested1: Swift.Equatable {
-    public var foo: Swift.String?
-    public var nested: Box<RecursiveShapesInputOutputNested2>?
+    var foo: Swift.String?
+    var nested: Box<RecursiveShapesInputOutputNested2>?
 
     public init (
         foo: Swift.String? = nil,
@@ -154,8 +154,8 @@ public struct RecursiveShapesInputOutputNested1: Swift.Equatable {
 }
 
 public struct RecursiveShapesInputOutputNested2: Swift.Equatable {
-    public var bar: Swift.String?
-    public var recursiveMember: RecursiveShapesInputOutputNested1?
+    var bar: Swift.String?
+    var recursiveMember: RecursiveShapesInputOutputNested1?
 
     public init (
         bar: Swift.String? = nil,
@@ -169,7 +169,7 @@ public struct RecursiveShapesInputOutputNested2: Swift.Equatable {
 
 /// This is documentation about the shape.
 public struct RecursiveShapesInputOutput: Swift.Equatable {
-    public var nested: RecursiveShapesInputOutputNested1?
+    var nested: RecursiveShapesInputOutputNested1?
 
     public init (
         nested: RecursiveShapesInputOutputNested1? = nil
@@ -198,8 +198,8 @@ public struct RecursiveShapesInputOutput: Swift.Equatable {
         val expected =
             """
 public struct RecursiveShapesInputOutputNestedList1: Swift.Equatable {
-    public var foo: Swift.String?
-    public var recursiveList: [RecursiveShapesInputOutputNested2]?
+    var foo: Swift.String?
+    var recursiveList: [RecursiveShapesInputOutputNested2]?
 
     public init (
         foo: Swift.String? = nil,
@@ -212,8 +212,8 @@ public struct RecursiveShapesInputOutputNestedList1: Swift.Equatable {
 }
 
 public struct RecursiveShapesInputOutputNested2: Swift.Equatable {
-    public var bar: Swift.String?
-    public var recursiveMember: RecursiveShapesInputOutputNested1?
+    var bar: Swift.String?
+    var recursiveMember: RecursiveShapesInputOutputNested1?
 
     public init (
         bar: Swift.String? = nil,
@@ -227,7 +227,7 @@ public struct RecursiveShapesInputOutputNested2: Swift.Equatable {
 
 /// This is documentation about the shape.
 public struct RecursiveShapesInputOutputLists: Swift.Equatable {
-    public var nested: RecursiveShapesInputOutputNested1?
+    var nested: RecursiveShapesInputOutputNested1?
 
     public init (
         nested: RecursiveShapesInputOutputNested1? = nil
@@ -311,13 +311,13 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
         val expectedContents =
             """
             public struct JsonListsInput: Swift.Equatable {
-                public var booleanList: [Swift.Bool]?
-                public var integerList: [Swift.Int]?
-                public var nestedStringList: [[Swift.String]]?
-                public var sparseStringList: [Swift.String?]?
-                public var stringList: [Swift.String]?
-                public var stringSet: Swift.Set<Swift.String>?
-                public var timestampList: [ClientRuntime.Date]?
+                var booleanList: [Swift.Bool]?
+                var integerList: [Swift.Int]?
+                var nestedStringList: [[Swift.String]]?
+                var sparseStringList: [Swift.String?]?
+                var stringList: [Swift.String]?
+                var stringSet: Swift.Set<Swift.String>?
+                var timestampList: [ClientRuntime.Date]?
             
                 public init (
                     booleanList: [Swift.Bool]? = nil,
@@ -359,14 +359,14 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
         val expectedJsonMapsInput =
             """
             public struct JsonMapsInput: Swift.Equatable {
-                public var denseBooleanMap: [Swift.String:Swift.Bool]?
-                public var denseNumberMap: [Swift.String:Swift.Int]?
-                public var denseStringMap: [Swift.String:Swift.String]?
-                public var denseStructMap: [Swift.String:ExampleClientTypes.GreetingStruct]?
-                public var sparseBooleanMap: [Swift.String:Swift.Bool?]?
-                public var sparseNumberMap: [Swift.String:Swift.Int?]?
-                public var sparseStringMap: [Swift.String:Swift.String?]?
-                public var sparseStructMap: [Swift.String:ExampleClientTypes.GreetingStruct?]?
+                var denseBooleanMap: [Swift.String:Swift.Bool]?
+                var denseNumberMap: [Swift.String:Swift.Int]?
+                var denseStringMap: [Swift.String:Swift.String]?
+                var denseStructMap: [Swift.String:ExampleClientTypes.GreetingStruct]?
+                var sparseBooleanMap: [Swift.String:Swift.Bool?]?
+                var sparseNumberMap: [Swift.String:Swift.Int?]?
+                var sparseStringMap: [Swift.String:Swift.String?]?
+                var sparseStructMap: [Swift.String:ExampleClientTypes.GreetingStruct?]?
             
                 public init (
                     denseBooleanMap: [Swift.String:Swift.Bool]? = nil,
@@ -398,14 +398,14 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
         val expectedJsonMapsOutput =
             """
             public struct JsonMapsOutputResponse: Swift.Equatable {
-                public var denseBooleanMap: [Swift.String:Swift.Bool]?
-                public var denseNumberMap: [Swift.String:Swift.Int]?
-                public var denseStringMap: [Swift.String:Swift.String]?
-                public var denseStructMap: [Swift.String:ExampleClientTypes.GreetingStruct]?
-                public var sparseBooleanMap: [Swift.String:Swift.Bool?]?
-                public var sparseNumberMap: [Swift.String:Swift.Int?]?
-                public var sparseStringMap: [Swift.String:Swift.String?]?
-                public var sparseStructMap: [Swift.String:ExampleClientTypes.GreetingStruct?]?
+                var denseBooleanMap: [Swift.String:Swift.Bool]?
+                var denseNumberMap: [Swift.String:Swift.Int]?
+                var denseStringMap: [Swift.String:Swift.String]?
+                var denseStructMap: [Swift.String:ExampleClientTypes.GreetingStruct]?
+                var sparseBooleanMap: [Swift.String:Swift.Bool?]?
+                var sparseNumberMap: [Swift.String:Swift.Int?]?
+                var sparseStringMap: [Swift.String:Swift.String?]?
+                var sparseStructMap: [Swift.String:ExampleClientTypes.GreetingStruct?]?
             
                 public init (
                     denseBooleanMap: [Swift.String:Swift.Bool]? = nil,
@@ -474,15 +474,15 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
         val structContainsDeprecatedMember = """
         @available(*, deprecated, message: "This shape is no longer used. API deprecated since 1.3")
         public struct OperationWithDeprecatedTraitInput: Swift.Equatable {
-            public var bool: Swift.Bool?
-            public var foo: ExampleClientTypes.Foo?
-            public var intVal: Swift.Int?
+            var bool: Swift.Bool?
+            var foo: ExampleClientTypes.Foo?
+            var intVal: Swift.Int?
             @available(*, deprecated)
-            public var string: Swift.String?
+            var string: Swift.String?
             @available(*, deprecated, message: " API deprecated since 2019-03-21")
-            public var structSincePropertySet: ExampleClientTypes.StructSincePropertySet?
+            var structSincePropertySet: ExampleClientTypes.StructSincePropertySet?
             @available(*, deprecated, message: "This shape is no longer used. API deprecated since 1.3")
-            public var structWithDeprecatedTrait: ExampleClientTypes.StructWithDeprecatedTrait?
+            var structWithDeprecatedTrait: ExampleClientTypes.StructWithDeprecatedTrait?
         """.trimIndent()
         structWithDeprecatedTraitMember.shouldContain(structContainsDeprecatedMember)
     }
@@ -502,9 +502,9 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
             public struct Foo: Swift.Equatable {
                 /// Test documentation with deprecated
                 @available(*, deprecated)
-                public var baz: Swift.String?
+                var baz: Swift.String?
                 /// Test documentation with deprecated
-                public var qux: Swift.String?
+                var qux: Swift.String?
         """.trimIndent()
         structWithDeprecatedTraitMember.shouldContain(structContainsDeprecatedMember)
     }

--- a/smithy-swift-codegen/src/test/kotlin/UnionDecodeGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/UnionDecodeGeneratorTests.kt
@@ -42,7 +42,7 @@ class UnionDecodeGeneratorTests {
         val expectedContents =
             """
             struct JsonUnionsOutputResponseBody: Swift.Equatable {
-                public let contents: ExampleClientTypes.MyUnion?
+                let contents: ExampleClientTypes.MyUnion?
             }
             
             extension JsonUnionsOutputResponseBody: Swift.Decodable {

--- a/smithy-swift-codegen/src/test/kotlin/serde/awsjson11/NestedListEncodeJSONGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/awsjson11/NestedListEncodeJSONGenerationTests.kt
@@ -18,7 +18,7 @@ class NestedListEncodeJSONGenerationTests {
         val expectedContents =
             """
             public struct ListOfMapsOperationInput: Swift.Equatable {
-                public var targetMaps: [[Swift.String:[Swift.String]]]?
+                var targetMaps: [[Swift.String:[Swift.String]]]?
             
                 public init (
                     targetMaps: [[Swift.String:[Swift.String]]]? = nil

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/EnumDecodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/EnumDecodeXMLGenerationTests.kt
@@ -20,10 +20,10 @@ class EnumDecodeXMLGenerationTests {
         val contents = getFileContents(context.manifest, "/RestXml/models/XmlEnumsOutputResponseBody+Decodable.swift")
         val expectedContents = """
         struct XmlEnumsOutputResponseBody: Swift.Equatable {
-            public let fooEnum1: RestXmlProtocolClientTypes.FooEnum?
-            public let fooEnum2: RestXmlProtocolClientTypes.FooEnum?
-            public let fooEnum3: RestXmlProtocolClientTypes.FooEnum?
-            public let fooEnumList: [RestXmlProtocolClientTypes.FooEnum]?
+            let fooEnum1: RestXmlProtocolClientTypes.FooEnum?
+            let fooEnum2: RestXmlProtocolClientTypes.FooEnum?
+            let fooEnum3: RestXmlProtocolClientTypes.FooEnum?
+            let fooEnumList: [RestXmlProtocolClientTypes.FooEnum]?
         }
         
         extension XmlEnumsOutputResponseBody: Swift.Decodable {
@@ -74,7 +74,7 @@ class EnumDecodeXMLGenerationTests {
         val expectedContents =
             """
             struct XmlEnumsNestedOutputResponseBody: Swift.Equatable {
-                public let nestedEnumsList: [[RestXmlProtocolClientTypes.FooEnum]]?
+                let nestedEnumsList: [[RestXmlProtocolClientTypes.FooEnum]]?
             }
             
             extension XmlEnumsNestedOutputResponseBody: Swift.Decodable {

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/StructDecodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/StructDecodeXMLGenerationTests.kt
@@ -59,16 +59,16 @@ class StructDecodeXMLGenerationTests {
         val contents = getFileContents(context.manifest, "/RestXml/models/SimpleScalarPropertiesOutputResponseBody+Decodable.swift")
         val expectedContents = """
         struct SimpleScalarPropertiesOutputResponseBody: Swift.Equatable {
-            public let stringValue: Swift.String?
-            public let trueBooleanValue: Swift.Bool?
-            public let falseBooleanValue: Swift.Bool?
-            public let byteValue: Swift.Int8?
-            public let shortValue: Swift.Int16?
-            public let integerValue: Swift.Int?
-            public let longValue: Swift.Int?
-            public let floatValue: Swift.Float?
-            public let `protocol`: Swift.String?
-            public let doubleValue: Swift.Double?
+            let stringValue: Swift.String?
+            let trueBooleanValue: Swift.Bool?
+            let falseBooleanValue: Swift.Bool?
+            let byteValue: Swift.Int8?
+            let shortValue: Swift.Int16?
+            let integerValue: Swift.Int?
+            let longValue: Swift.Int?
+            let floatValue: Swift.Float?
+            let `protocol`: Swift.String?
+            let doubleValue: Swift.Double?
         }
         
         extension SimpleScalarPropertiesOutputResponseBody: Swift.Decodable {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This PR contains two fixes as suggested by Apple to decrease binary size:
- decrease usage of the word public where not needed
- decrease generation of CustomDebugStringConvertible Conformance where not needed.
For reference this takes Lambda down to 25.7 MB from 29.5 MB now.

Corresponding PR: https://github.com/awslabs/aws-sdk-swift/pull/539

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.