### PR TITLE
fix: revert public modifier change

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/StructureGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/StructureGenerator.kt
@@ -126,7 +126,7 @@ class StructureGenerator(
             }
 
             writer.writeAvailableAttribute(model, it)
-            writer.write("var \$L: \$T", memberName, memberSymbol)
+            writer.write("public var \$L: \$T", memberName, memberSymbol)
         }
     }
 

--- a/smithy-swift-codegen/src/test/kotlin/HashableShapeTransformerTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HashableShapeTransformerTests.kt
@@ -70,8 +70,8 @@ class HashableShapeTransformerTests {
         Assertions.assertNotNull(hashableShapeInput)
         val expected = """
             public struct HashableShapesInput: Swift.Equatable {
-                var `set`: Swift.Set<ExampleClientTypes.HashableStructure>?
-                var bar: Swift.String?
+                public var `set`: Swift.Set<ExampleClientTypes.HashableStructure>?
+                public var bar: Swift.String?
             
                 public init (
                     `set`: Swift.Set<ExampleClientTypes.HashableStructure>? = nil,
@@ -90,7 +90,7 @@ class HashableShapeTransformerTests {
         Assertions.assertNotNull(hashableShapeOutput)
         val expectedOutput = """
             public struct HashableShapesOutputResponse: Swift.Equatable {
-                var quz: Swift.String?
+                public var quz: Swift.String?
             
                 public init (
                     quz: Swift.String? = nil
@@ -108,8 +108,8 @@ class HashableShapeTransformerTests {
         val expectedStructureShape = """
             extension ExampleClientTypes {
                 public struct HashableStructure: Swift.Equatable, Swift.Hashable {
-                    var baz: ExampleClientTypes.NestedHashableStructure?
-                    var foo: Swift.String?
+                    public var baz: ExampleClientTypes.NestedHashableStructure?
+                    public var foo: Swift.String?
             
                     public init (
                         baz: ExampleClientTypes.NestedHashableStructure? = nil,
@@ -131,8 +131,8 @@ class HashableShapeTransformerTests {
         val expectedNestedStructureShape = """
         extension ExampleClientTypes {
             public struct NestedHashableStructure: Swift.Equatable, Swift.Hashable {
-                var bar: Swift.String?
-                var quz: Swift.Int?
+                public var bar: Swift.String?
+                public var quz: Swift.Int?
         
                 public init (
                     bar: Swift.String? = nil,

--- a/smithy-swift-codegen/src/test/kotlin/RecursiveShapeBoxerTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/RecursiveShapeBoxerTests.kt
@@ -51,7 +51,7 @@ internal class RecursiveShapeBoxerTests {
         val expected =
             """
             public struct RecursiveShapesInput: Swift.Equatable {
-                var nested: ExampleClientTypes.RecursiveShapesInputOutputNested1?
+                public var nested: ExampleClientTypes.RecursiveShapesInputOutputNested1?
             
                 public init (
                     nested: ExampleClientTypes.RecursiveShapesInputOutputNested1? = nil
@@ -69,7 +69,7 @@ internal class RecursiveShapeBoxerTests {
         val expected2 =
             """
             public struct RecursiveShapesOutputResponse: Swift.Equatable {
-                var nested: ExampleClientTypes.RecursiveShapesInputOutputNested1?
+                public var nested: ExampleClientTypes.RecursiveShapesInputOutputNested1?
             
                 public init (
                     nested: ExampleClientTypes.RecursiveShapesInputOutputNested1? = nil
@@ -88,8 +88,8 @@ internal class RecursiveShapeBoxerTests {
             """
             extension ExampleClientTypes {
                 public struct RecursiveShapesInputOutputNested1: Swift.Equatable {
-                    var foo: Swift.String?
-                    var nested: Box<ExampleClientTypes.RecursiveShapesInputOutputNested2>?
+                    public var foo: Swift.String?
+                    public var nested: Box<ExampleClientTypes.RecursiveShapesInputOutputNested2>?
             
                     public init (
                         foo: Swift.String? = nil,
@@ -112,8 +112,8 @@ internal class RecursiveShapeBoxerTests {
             """
         extension ExampleClientTypes {
             public struct RecursiveShapesInputOutputNested2: Swift.Equatable {
-                var bar: Swift.String?
-                var recursiveMember: ExampleClientTypes.RecursiveShapesInputOutputNested1?
+                public var bar: Swift.String?
+                public var recursiveMember: ExampleClientTypes.RecursiveShapesInputOutputNested1?
         
                 public init (
                     bar: Swift.String? = nil,

--- a/smithy-swift-codegen/src/test/kotlin/ServiceRenamesTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/ServiceRenamesTests.kt
@@ -22,7 +22,7 @@ class ServiceRenamesTests {
         val expectedContents =
             """
             public struct MyTestOperationInput: Swift.Equatable {
-                var bar: ExampleClientTypes.RenamedGreeting?
+                public var bar: ExampleClientTypes.RenamedGreeting?
             
                 public init (
                     bar: ExampleClientTypes.RenamedGreeting? = nil
@@ -50,7 +50,7 @@ class ServiceRenamesTests {
         val expectedContents =
             """
             public struct MyTestOperationOutputResponse: Swift.Equatable {
-                var baz: ExampleClientTypes.GreetingStruct?
+                public var baz: ExampleClientTypes.GreetingStruct?
             
                 public init (
                     baz: ExampleClientTypes.GreetingStruct? = nil
@@ -79,7 +79,7 @@ class ServiceRenamesTests {
             """
             extension ExampleClientTypes {
                 public struct GreetingStruct: Swift.Equatable {
-                    var hi: Swift.String?
+                    public var hi: Swift.String?
             
                     public init (
                         hi: Swift.String? = nil
@@ -111,7 +111,7 @@ class ServiceRenamesTests {
             """
             extension ExampleClientTypes {
                 public struct RenamedGreeting: Swift.Equatable {
-                    var salutation: Swift.String?
+                    public var salutation: Swift.String?
             
                     public init (
                         salutation: Swift.String? = nil

--- a/smithy-swift-codegen/src/test/kotlin/StructEncodeGenerationIsolatedTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/StructEncodeGenerationIsolatedTests.kt
@@ -35,8 +35,8 @@ class StructEncodeGenerationIsolatedTests {
         val expectedContents =
             """
             public struct EnumInputInput: Swift.Equatable {
-                var enumHeader: ExampleClientTypes.MyEnum?
-                var nestedWithEnum: ExampleClientTypes.NestedEnum?
+                public var enumHeader: ExampleClientTypes.MyEnum?
+                public var nestedWithEnum: ExampleClientTypes.NestedEnum?
             """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
     }

--- a/smithy-swift-codegen/src/test/kotlin/StructureGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/StructureGeneratorTests.kt
@@ -36,10 +36,10 @@ class StructureGeneratorTests {
             """
             /// This is documentation about the shape.
             public struct MyStruct: Swift.Equatable {
-                var bar: Swift.Int
+                public var bar: Swift.Int
                 /// This is documentation about the member.
-                var baz: Swift.Int?
-                var foo: Swift.String?
+                public var baz: Swift.Int?
+                public var foo: Swift.String?
             
                 public init (
                     bar: Swift.Int = 0,
@@ -69,21 +69,21 @@ class StructureGeneratorTests {
         val expected =
             """
         public struct PrimitiveTypesInput: Swift.Equatable {
-            var booleanVal: Swift.Bool?
-            var byteVal: Swift.Int8?
-            var doubleVal: Swift.Double?
-            var floatVal: Swift.Float?
-            var intVal: Swift.Int?
-            var longVal: Swift.Int?
-            var primitiveBooleanVal: Swift.Bool
-            var primitiveByteVal: Swift.Int8
-            var primitiveDoubleVal: Swift.Double
-            var primitiveFloatVal: Swift.Float
-            var primitiveIntVal: Swift.Int
-            var primitiveLongVal: Swift.Int
-            var primitiveShortVal: Swift.Int16
-            var shortVal: Swift.Int16?
-            var str: Swift.String?
+            public var booleanVal: Swift.Bool?
+            public var byteVal: Swift.Int8?
+            public var doubleVal: Swift.Double?
+            public var floatVal: Swift.Float?
+            public var intVal: Swift.Int?
+            public var longVal: Swift.Int?
+            public var primitiveBooleanVal: Swift.Bool
+            public var primitiveByteVal: Swift.Int8
+            public var primitiveDoubleVal: Swift.Double
+            public var primitiveFloatVal: Swift.Float
+            public var primitiveIntVal: Swift.Int
+            public var primitiveLongVal: Swift.Int
+            public var primitiveShortVal: Swift.Int16
+            public var shortVal: Swift.Int16?
+            public var str: Swift.String?
         
             public init (
                 booleanVal: Swift.Bool? = nil,
@@ -140,8 +140,8 @@ class StructureGeneratorTests {
         val expected =
             """
 public struct RecursiveShapesInputOutputNested1: Swift.Equatable {
-    var foo: Swift.String?
-    var nested: Box<RecursiveShapesInputOutputNested2>?
+    public var foo: Swift.String?
+    public var nested: Box<RecursiveShapesInputOutputNested2>?
 
     public init (
         foo: Swift.String? = nil,
@@ -154,8 +154,8 @@ public struct RecursiveShapesInputOutputNested1: Swift.Equatable {
 }
 
 public struct RecursiveShapesInputOutputNested2: Swift.Equatable {
-    var bar: Swift.String?
-    var recursiveMember: RecursiveShapesInputOutputNested1?
+    public var bar: Swift.String?
+    public var recursiveMember: RecursiveShapesInputOutputNested1?
 
     public init (
         bar: Swift.String? = nil,
@@ -169,7 +169,7 @@ public struct RecursiveShapesInputOutputNested2: Swift.Equatable {
 
 /// This is documentation about the shape.
 public struct RecursiveShapesInputOutput: Swift.Equatable {
-    var nested: RecursiveShapesInputOutputNested1?
+    public var nested: RecursiveShapesInputOutputNested1?
 
     public init (
         nested: RecursiveShapesInputOutputNested1? = nil
@@ -198,8 +198,8 @@ public struct RecursiveShapesInputOutput: Swift.Equatable {
         val expected =
             """
 public struct RecursiveShapesInputOutputNestedList1: Swift.Equatable {
-    var foo: Swift.String?
-    var recursiveList: [RecursiveShapesInputOutputNested2]?
+    public var foo: Swift.String?
+    public var recursiveList: [RecursiveShapesInputOutputNested2]?
 
     public init (
         foo: Swift.String? = nil,
@@ -212,8 +212,8 @@ public struct RecursiveShapesInputOutputNestedList1: Swift.Equatable {
 }
 
 public struct RecursiveShapesInputOutputNested2: Swift.Equatable {
-    var bar: Swift.String?
-    var recursiveMember: RecursiveShapesInputOutputNested1?
+    public var bar: Swift.String?
+    public var recursiveMember: RecursiveShapesInputOutputNested1?
 
     public init (
         bar: Swift.String? = nil,
@@ -227,7 +227,7 @@ public struct RecursiveShapesInputOutputNested2: Swift.Equatable {
 
 /// This is documentation about the shape.
 public struct RecursiveShapesInputOutputLists: Swift.Equatable {
-    var nested: RecursiveShapesInputOutputNested1?
+    public var nested: RecursiveShapesInputOutputNested1?
 
     public init (
         nested: RecursiveShapesInputOutputNested1? = nil
@@ -311,13 +311,13 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
         val expectedContents =
             """
             public struct JsonListsInput: Swift.Equatable {
-                var booleanList: [Swift.Bool]?
-                var integerList: [Swift.Int]?
-                var nestedStringList: [[Swift.String]]?
-                var sparseStringList: [Swift.String?]?
-                var stringList: [Swift.String]?
-                var stringSet: Swift.Set<Swift.String>?
-                var timestampList: [ClientRuntime.Date]?
+                public var booleanList: [Swift.Bool]?
+                public var integerList: [Swift.Int]?
+                public var nestedStringList: [[Swift.String]]?
+                public var sparseStringList: [Swift.String?]?
+                public var stringList: [Swift.String]?
+                public var stringSet: Swift.Set<Swift.String>?
+                public var timestampList: [ClientRuntime.Date]?
             
                 public init (
                     booleanList: [Swift.Bool]? = nil,
@@ -359,14 +359,14 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
         val expectedJsonMapsInput =
             """
             public struct JsonMapsInput: Swift.Equatable {
-                var denseBooleanMap: [Swift.String:Swift.Bool]?
-                var denseNumberMap: [Swift.String:Swift.Int]?
-                var denseStringMap: [Swift.String:Swift.String]?
-                var denseStructMap: [Swift.String:ExampleClientTypes.GreetingStruct]?
-                var sparseBooleanMap: [Swift.String:Swift.Bool?]?
-                var sparseNumberMap: [Swift.String:Swift.Int?]?
-                var sparseStringMap: [Swift.String:Swift.String?]?
-                var sparseStructMap: [Swift.String:ExampleClientTypes.GreetingStruct?]?
+                public var denseBooleanMap: [Swift.String:Swift.Bool]?
+                public var denseNumberMap: [Swift.String:Swift.Int]?
+                public var denseStringMap: [Swift.String:Swift.String]?
+                public var denseStructMap: [Swift.String:ExampleClientTypes.GreetingStruct]?
+                public var sparseBooleanMap: [Swift.String:Swift.Bool?]?
+                public var sparseNumberMap: [Swift.String:Swift.Int?]?
+                public var sparseStringMap: [Swift.String:Swift.String?]?
+                public var sparseStructMap: [Swift.String:ExampleClientTypes.GreetingStruct?]?
             
                 public init (
                     denseBooleanMap: [Swift.String:Swift.Bool]? = nil,
@@ -398,14 +398,14 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
         val expectedJsonMapsOutput =
             """
             public struct JsonMapsOutputResponse: Swift.Equatable {
-                var denseBooleanMap: [Swift.String:Swift.Bool]?
-                var denseNumberMap: [Swift.String:Swift.Int]?
-                var denseStringMap: [Swift.String:Swift.String]?
-                var denseStructMap: [Swift.String:ExampleClientTypes.GreetingStruct]?
-                var sparseBooleanMap: [Swift.String:Swift.Bool?]?
-                var sparseNumberMap: [Swift.String:Swift.Int?]?
-                var sparseStringMap: [Swift.String:Swift.String?]?
-                var sparseStructMap: [Swift.String:ExampleClientTypes.GreetingStruct?]?
+                public var denseBooleanMap: [Swift.String:Swift.Bool]?
+                public var denseNumberMap: [Swift.String:Swift.Int]?
+                public var denseStringMap: [Swift.String:Swift.String]?
+                public var denseStructMap: [Swift.String:ExampleClientTypes.GreetingStruct]?
+                public var sparseBooleanMap: [Swift.String:Swift.Bool?]?
+                public var sparseNumberMap: [Swift.String:Swift.Int?]?
+                public var sparseStringMap: [Swift.String:Swift.String?]?
+                public var sparseStructMap: [Swift.String:ExampleClientTypes.GreetingStruct?]?
             
                 public init (
                     denseBooleanMap: [Swift.String:Swift.Bool]? = nil,
@@ -474,15 +474,15 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
         val structContainsDeprecatedMember = """
         @available(*, deprecated, message: "This shape is no longer used. API deprecated since 1.3")
         public struct OperationWithDeprecatedTraitInput: Swift.Equatable {
-            var bool: Swift.Bool?
-            var foo: ExampleClientTypes.Foo?
-            var intVal: Swift.Int?
+            public var bool: Swift.Bool?
+            public var foo: ExampleClientTypes.Foo?
+            public var intVal: Swift.Int?
             @available(*, deprecated)
-            var string: Swift.String?
+            public var string: Swift.String?
             @available(*, deprecated, message: " API deprecated since 2019-03-21")
-            var structSincePropertySet: ExampleClientTypes.StructSincePropertySet?
+            public var structSincePropertySet: ExampleClientTypes.StructSincePropertySet?
             @available(*, deprecated, message: "This shape is no longer used. API deprecated since 1.3")
-            var structWithDeprecatedTrait: ExampleClientTypes.StructWithDeprecatedTrait?
+            public var structWithDeprecatedTrait: ExampleClientTypes.StructWithDeprecatedTrait?
         """.trimIndent()
         structWithDeprecatedTraitMember.shouldContain(structContainsDeprecatedMember)
     }
@@ -502,9 +502,9 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
             public struct Foo: Swift.Equatable {
                 /// Test documentation with deprecated
                 @available(*, deprecated)
-                var baz: Swift.String?
+                public var baz: Swift.String?
                 /// Test documentation with deprecated
-                var qux: Swift.String?
+                public var qux: Swift.String?
         """.trimIndent()
         structWithDeprecatedTraitMember.shouldContain(structContainsDeprecatedMember)
     }

--- a/smithy-swift-codegen/src/test/kotlin/serde/awsjson11/NestedListEncodeJSONGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/awsjson11/NestedListEncodeJSONGenerationTests.kt
@@ -18,7 +18,7 @@ class NestedListEncodeJSONGenerationTests {
         val expectedContents =
             """
             public struct ListOfMapsOperationInput: Swift.Equatable {
-                var targetMaps: [[Swift.String:[Swift.String]]]?
+                public var targetMaps: [[Swift.String:[Swift.String]]]?
             
                 public init (
                     targetMaps: [[Swift.String:[Swift.String]]]? = nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This reverts one of the changes made in https://github.com/awslabs/smithy-swift/pull/403 that went too far in removing public modifiers needed by customers. One of them that was removed was not needed but one was. This puts that one back.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.