### PR TITLE
fix: add Swift 5.6 case in swiftVersion property to resolve compiler error

### DIFF
--- a/Packages/ClientRuntime/Sources/Util/SwiftVersion.swift
+++ b/Packages/ClientRuntime/Sources/Util/SwiftVersion.swift
@@ -6,8 +6,10 @@
 //
 
 public var swiftVersion: String {
-    #if swift(>=5.6)
+    #if swift(>=5.7)
       #error("Cannot use a version of Swift greater than available. Please create a Github issue for us to add support for the version of Swift you want to use.")
+    #elseif swift(>=5.6)
+    return "5.6"
     #elseif swift(>=5.5)
     return "5.5"
     #elseif swift(>=5.4)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
smithy-swift (and thereby the AWSSwiftSDK) throw a compiler error when building with Swift 5.6
This is a quick fix that resolves the compiler error and doesn't break anything else based on manual testing.

Next step would be supporting Swift 5.6 language features, e.g. `any P`. That change should come in a subsequent feat PR so we can fix the existing issue quickly.

Side note: Swift 5.7 has been confirmed as the next major version. However If we want to keep this language version checking strategy going forward, it may make sense to switch to `> existing version` rather than `>= potential next version`. 

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] ~New feature (non-breaking change which adds functionality)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.