### PR TITLE
Add a public initializer for structures with no members.

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/StructureGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/StructureGenerator.kt
@@ -150,6 +150,8 @@ class StructureGenerator(
                     writer.write("self.\$1L = \$1L", memberName)
                 }
             }
+        } else {
+            writer.write("public init () { }")
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/568

## Description of changes
Structures with no members have no way to be initialised by consumers.


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.