### PR TITLE
Emit logs at the severity specified at the call site.

### DIFF
--- a/Packages/ClientRuntime/Sources/Logging/SwiftLog+LogAgent.swift
+++ b/Packages/ClientRuntime/Sources/Logging/SwiftLog+LogAgent.swift
@@ -6,22 +6,20 @@
 import Logging
 
 public struct SwiftLogger: LogAgent {
-    private let logger: Logger
+    private var logger: Logger
     private let label: String
-    private var logLevel: LogAgentLevel
 
     public init(label: String) {
         self.label = label
         self.logger = Logger(label: label)
-        self.logLevel = LogAgentLevel.info
     }
 
     public var level: LogAgentLevel {
         get {
-            return logLevel
+            return self.logger.logLevel.toLogAgentLevel()
         }
         set(value) {
-            logLevel = value
+            self.logger.logLevel = value.toLoggerLevel()
         }
     }
 
@@ -39,13 +37,32 @@ public struct SwiftLogger: LogAgent {
         let mappedDict = metadata?.mapValues { (value) -> Logger.MetadataValue in
             return Logger.MetadataValue.string(value)
         }
-        self.logger.log(level: logLevel.toLoggerLevel(),
+        self.logger.log(level: level.toLoggerLevel(),
                         Logger.Message(stringLiteral: message),
                         metadata: mappedDict,
                         source: source,
                         file: file,
                         function: function,
                         line: line)
+    }
+}
+
+extension Logger.Level {
+    func toLogAgentLevel() -> LogAgentLevel {
+        switch self {
+        case .trace:
+            return .trace
+        case .debug:
+            return .debug
+        case .info, .notice:
+            return .info
+        case .warning:
+            return .warn
+        case .error:
+            return .error
+        case .critical:
+            return .fatal
+        }
     }
 }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description of changes
1. Emit logs at the severity specified at the call site rather than the `logLevel` of `SwiftLogger`. 
2. Make the logging level of `SwiftLogger` defer to the underlying logger.
3. Lower the severity of some logs in the CRTClientEngine to align with [1] as these seem to be logging about inner detail.


[1] https://github.com/swift-server/guides/blob/main/docs/libs/log-levels.md


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.