### PR TITLE
PaginatorSequence should return values even if there is only one page of values

### DIFF
--- a/Packages/ClientRuntime/Sources/Pagination/PaginatorSequence.swift
+++ b/Packages/ClientRuntime/Sources/Pagination/PaginatorSequence.swift
@@ -42,7 +42,7 @@ where Input.Token: Equatable {
                 let output = try await sequence.paginationFunction(input)
                 isFirstPage = false
                 token = output[keyPath: sequence.outputKey]
-                if token == input[keyPath: sequence.inputKey!] {
+                if token != nil && token == input[keyPath: sequence.inputKey!] {
                     break
                 }
                 return output


### PR DESCRIPTION
## Issue
This fixes an open issue on the AWS Swift SDK repo awslabs/aws-sdk-swift#588.

## Description of changes
* The `PaginatorSequence` struct does not return values if there is only one page of values (no pagination required).
* This is because of a code block that breaks the loop if the input page token and the page token in the API response are equal. But if there is only one page of values, then both input page token and page token in the API response would both be `nil`.

## Code snippet to reproduce issue

```swift
import AWSCloudWatchLogs
import AWSClientRuntime

let aws_config = AWSCredentialsProviderStaticConfig(
    accessKey: "REPLACE_THIS",
    secret: "REPLACE_THIS"
)

do {
    let client_config = try CloudWatchLogsClient.CloudWatchLogsClientConfiguration(
        region: "us-west-2",
        credentialsProvider: AWSCredentialsProvider.fromStatic(aws_config)
    )
    let client = CloudWatchLogsClient(config: client_config)
    let response = client.describeLogGroupsPaginated(input: DescribeLogGroupsInput())
    
    print("Printing output...")
    for try await i in response {
        print("--- Received log line ---")
        print(i)
    }
    print("-#-#- Call to AWS complete")
} catch {
  print("AWS init error")
}
```

> *For test scenarios/examples before fix, please refer to notes on awslabs/aws-sdk-swift#588*

## Test scenarios after fix

### [Scenario] Should return any values from first page if no pagination required

> *This was the scenario with the issue reported in awslabs/aws-sdk-swift#588*.

This scenario was run without any changes to the code snippet posted above. Log output below.

```
client config successful
Printing output...
2022-07-13T17:09:37+0700 info CloudWatchLogsClient : Request: POST https:443 
 Path: /, 
 Authorization: REDACTED, 
User-Agent: aws-sdk-swift/1.0 api/cloudwatch-logs/1.0 os/macOS/12.4.0 lang/swift/5.6, 
X-Amz-Date: 20220713T100937Z, 
Content-Type: application/x-amz-json-1.1, 
X-Amz-Target: Logs_20140328.DescribeLogGroups, 
Host: logs.us-west-2.amazonaws.com, 
Content-Length: 2, 
x-amz-user-agent: aws-sdk-swift/1.0 
 Optional([])
2022-07-13T17:09:37+0700 info CRTClientEngine : Creating connection pool for Optional("https://logs.us-west-2.amazonaws.com/?")with max connections: 50
2022-07-13T17:09:39+0700 info CRTClientEngine : Connection was acquired to: Optional("https://logs.us-west-2.amazonaws.com/?")
2022-07-13T17:09:39+0700 info CRTClientEngine : headers were received
2022-07-13T17:09:39+0700 info CRTClientEngine : headers were received
2022-07-13T17:09:39+0700 info CRTClientEngine : headers were received
2022-07-13T17:09:39+0700 info CRTClientEngine : headers were received
2022-07-13T17:09:39+0700 info CRTClientEngine : header block is done
2022-07-13T17:09:39+0700 info CRTClientEngine : incoming data
2022-07-13T17:09:39+0700 info CRTClientEngine : stream completed
--- Received log line ---
DescribeLogGroupsOutputResponse(REDACTED)
-#-#- Call to AWS complete
2022-07-13T17:09:39+0700 info CRTClientEngine : Connection to endpoint: Optional("https://logs.us-west-2.amazonaws.com/?") is closing
```

### [Scenario] Should return values paginated if there are more than one page of values

> *This scenario worked fine before the fix too. Just testing this to ensure nothing else breaks.*

* The below scenario was run after updating the pagination input to `1` in the above example code snippet.
* Change `DescribeLogGroupsInput()` to `DescribeLogGroupsInput(limit: 1)` to reproduce below scenario.
* The log groups would all be listed one per page (so 3 pages).

Log output below.

```
client config successful
Printing output...
2022-07-13T17:17:58+0700 info CloudWatchLogsClient : Request: POST https:443 
 Path: /, 
 Content-Type: application/x-amz-json-1.1, 
Content-Length: 11, 
X-Amz-Target: Logs_20140328.DescribeLogGroups, 
Host: logs.us-west-2.amazonaws.com, 
x-amz-user-agent: aws-sdk-swift/1.0, 
Authorization: REDACTED, 
X-Amz-Date: 20220713T101758Z, 
User-Agent: aws-sdk-swift/1.0 api/cloudwatch-logs/1.0 os/macOS/12.4.0 lang/swift/5.6 
 Optional([])
2022-07-13T17:17:58+0700 info CRTClientEngine : Creating connection pool for Optional("https://logs.us-west-2.amazonaws.com/?")with max connections: 50
2022-07-13T17:18:00+0700 info CRTClientEngine : Connection was acquired to: Optional("https://logs.us-west-2.amazonaws.com/?")
2022-07-13T17:18:00+0700 info CRTClientEngine : headers were received
2022-07-13T17:18:00+0700 info CRTClientEngine : headers were received
2022-07-13T17:18:00+0700 info CRTClientEngine : headers were received
2022-07-13T17:18:00+0700 info CRTClientEngine : headers were received
2022-07-13T17:18:00+0700 info CRTClientEngine : header block is done
2022-07-13T17:18:00+0700 info CRTClientEngine : incoming data
2022-07-13T17:18:00+0700 info CRTClientEngine : stream completed
--- Received log line ---
DescribeLogGroupsOutputResponse(REDACTED)
2022-07-13T17:18:00+0700 info CloudWatchLogsClient : Request: POST https:443 
 Path: /, 
 X-Amz-Target: Logs_20140328.DescribeLogGroups, 
Content-Type: application/x-amz-json-1.1, 
Host: logs.us-west-2.amazonaws.com, 
User-Agent: aws-sdk-swift/1.0 api/cloudwatch-logs/1.0 os/macOS/12.4.0 lang/swift/5.6, 
X-Amz-Date: 20220713T101800Z, 
Authorization: REDACTED,
Content-Length: 82, 
x-amz-user-agent: aws-sdk-swift/1.0 
 Optional([])
2022-07-13T17:18:02+0700 info CRTClientEngine : Connection was acquired to: Optional("https://logs.us-west-2.amazonaws.com/?")
2022-07-13T17:18:02+0700 info CRTClientEngine : headers were received
2022-07-13T17:18:02+0700 info CRTClientEngine : headers were received
2022-07-13T17:18:02+0700 info CRTClientEngine : headers were received
2022-07-13T17:18:02+0700 info CRTClientEngine : headers were received
2022-07-13T17:18:02+0700 info CRTClientEngine : header block is done
2022-07-13T17:18:02+0700 info CRTClientEngine : incoming data
2022-07-13T17:18:02+0700 info CRTClientEngine : stream completed
--- Received log line ---
DescribeLogGroupsOutputResponse(REDACTED)
2022-07-13T17:18:02+0700 info CloudWatchLogsClient : Request: POST https:443 
 Path: /, 
 Content-Length: 104, 
Authorization: REDACTED,
Content-Type: application/x-amz-json-1.1, 
x-amz-user-agent: aws-sdk-swift/1.0, 
User-Agent: aws-sdk-swift/1.0 api/cloudwatch-logs/1.0 os/macOS/12.4.0 lang/swift/5.6, 
X-Amz-Target: Logs_20140328.DescribeLogGroups, 
Host: logs.us-west-2.amazonaws.com, 
X-Amz-Date: 20220713T101802Z 
 Optional([])
2022-07-13T17:18:04+0700 info CRTClientEngine : Connection was acquired to: Optional("https://logs.us-west-2.amazonaws.com/?")
2022-07-13T17:18:05+0700 info CRTClientEngine : headers were received
2022-07-13T17:18:05+0700 info CRTClientEngine : headers were received
2022-07-13T17:18:05+0700 info CRTClientEngine : headers were received
2022-07-13T17:18:05+0700 info CRTClientEngine : headers were received
2022-07-13T17:18:05+0700 info CRTClientEngine : header block is done
2022-07-13T17:18:05+0700 info CRTClientEngine : incoming data
2022-07-13T17:18:05+0700 info CRTClientEngine : stream completed
--- Received log line ---
DescribeLogGroupsOutputResponse(REDACTED)
-#-#- Call to AWS complete
2022-07-13T17:18:05+0700 info CRTClientEngine : Connection to endpoint: Optional("https://logs.us-west-2.amazonaws.com/?") is closing
```

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.