### PR TITLE
removes the redundant call for releaseToken

### DIFF
--- a/Packages/ClientRuntime/Sources/Retries/Retryer.swift
+++ b/Packages/ClientRuntime/Sources/Retries/Retryer.swift
@@ -9,6 +9,7 @@ protocol Retryer {
     func acquireToken(partitionId: String) async throws -> RetryToken
     func scheduleRetry(token: RetryToken, error: RetryError) async throws -> RetryToken
     func recordSuccess(token: RetryToken)
+    @available(*, deprecated, message: "This function will be removed soon.")
     func releaseToken(token: RetryToken)
     func isErrorRetryable<E>(error: SdkError<E>) -> Bool
     func getErrorType<E>(error: SdkError<E>) -> RetryError

--- a/Packages/ClientRuntime/Sources/Retries/SDKRetryer.swift
+++ b/Packages/ClientRuntime/Sources/Retries/SDKRetryer.swift
@@ -34,8 +34,8 @@ public class SDKRetryer: Retryer {
         crtRetryStrategy.recordSuccess(token: token.crtToken)
     }
     
+    @available(*, deprecated, message: "This function will be removed soon.")
     public func releaseToken(token: RetryToken) {
-        crtRetryStrategy.releaseToken(token: token.crtToken)
     }
     
     public func isErrorRetryable<E>(error: SdkError<E>) -> Bool {


### PR DESCRIPTION
this change eliminates a redundant call to releaseToken

Related: https://github.com/awslabs/aws-crt-swift/issues/66