### PR TITLE
fixes data race in CRTClientEngine

### DIFF
--- a/Packages/ClientRuntime/Sources/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/CRT/CRTClientEngine.swift
@@ -11,7 +11,7 @@ import Darwin
 #endif
 
 public class CRTClientEngine: HttpClientEngine {
-    actor ConnectionPoolContainer {
+    actor SerialExecutor {
         private var logger: LogAgent
 
         private let windowSize: Int
@@ -21,7 +21,7 @@ public class CRTClientEngine: HttpClientEngine {
         init(config: CRTClientEngineConfig) {
             self.windowSize = config.windowSize
             self.maxConnectionsPerEndpoint = config.maxConnectionsPerEndpoint
-            self.logger = SwiftLogger(label: "ConnectionPoolContainer")
+            self.logger = SwiftLogger(label: "SerialExecutor")
         }
 
         func getOrCreateConnectionPool(endpoint: Endpoint) -> HttpClientConnectionManager {
@@ -71,7 +71,7 @@ public class CRTClientEngine: HttpClientEngine {
 
     public typealias StreamContinuation = CheckedContinuation<HttpResponse, Error>
     private var logger: LogAgent
-    private let connectonPoolContainer: ConnectionPoolContainer
+    private let connectonPoolContainer: SerialExecutor
     private let CONTENT_LENGTH_HEADER = "Content-Length"
     private let AWS_COMMON_RUNTIME = "AwsCommonRuntime"
     private let DEFAULT_STREAM_WINDOW_SIZE = 16 * 1024 * 1024 // 16 MB
@@ -84,7 +84,7 @@ public class CRTClientEngine: HttpClientEngine {
         self.maxConnectionsPerEndpoint = config.maxConnectionsPerEndpoint
         self.windowSize = config.windowSize
         self.logger = SwiftLogger(label: "CRTClientEngine")
-        self.connectonPoolContainer = ConnectionPoolContainer(config: config)
+        self.connectonPoolContainer = SerialExecutor(config: config)
     }
     
     public func execute(request: SdkHttpRequest) async throws -> HttpResponse {

--- a/Packages/ClientRuntime/Sources/Networking/Http/HttpClientEngine.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/HttpClientEngine.swift
@@ -6,5 +6,5 @@ import AwsCommonRuntimeKit
 
 public protocol HttpClientEngine {
     func execute(request: SdkHttpRequest) async throws -> HttpResponse
-    func close()
+    func close() async
 }

--- a/Packages/ClientRuntime/Sources/Networking/Http/SdkHttpClient.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/SdkHttpClient.swift
@@ -24,7 +24,9 @@ public class SdkHttpClient {
     }
     
     public func close() {
-        engine.close()
+        Task.detached {
+            await self.engine.close()
+        }
     }
     
 }

--- a/Packages/ClientRuntime/Sources/Networking/Http/SdkHttpClient.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/SdkHttpClient.swift
@@ -24,7 +24,7 @@ public class SdkHttpClient {
     }
     
     public func close() {
-        Task.detached {
+        Task {
             await self.engine.close()
         }
     }


### PR DESCRIPTION
* creates nested actor named ConnectionPoolContainer in CRTClientEngine
* public functions were directed to the actor to manage connection pools

<!--- Provide a general summary of your changes in the Title above -->

## Issue \#

#423

## Description of changes

Moves state management into an `actor` to make it thread-safe.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.