### PR TITLE
Ignore deprecated traits for shapes in the prelude

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,8 @@ plugins {
 
 allprojects {
     repositories {
-        mavenCentral()
         mavenLocal()
+        mavenCentral()	
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ kotlin.code.style=official
 # config
 
 # codegen
-smithyVersion=1.13.1
-smithyGradleVersion=0.5.3
+smithyVersion=1.22.0
+smithyGradleVersion=0.6.0
 
 # kotlin
 kotlinVersion=1.5.31

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftWriter.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftWriter.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.codegen.core.SymbolDependency
 import software.amazon.smithy.codegen.core.SymbolDependencyContainer
 import software.amazon.smithy.codegen.core.SymbolReference
 import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.loader.Prelude
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.traits.DeprecatedTrait
@@ -212,7 +213,13 @@ class SwiftWriter(private val fullPackageName: String) : CodeWriter() {
         if (shape.getTrait(DeprecatedTrait::class.java).isPresent) {
             deprecatedTrait = shape.getTrait(DeprecatedTrait::class.java).get()
         } else if (shape.getMemberTrait(model, DeprecatedTrait::class.java).isPresent) {
-            deprecatedTrait = shape.getMemberTrait(model, DeprecatedTrait::class.java).get()
+            if (shape is MemberShape) {
+                if (!Prelude.isPreludeShape(shape.getTarget())) {
+                    deprecatedTrait = shape.getMemberTrait(model, DeprecatedTrait::class.java).get()
+                }
+            } else {
+                deprecatedTrait = shape.getMemberTrait(model, DeprecatedTrait::class.java).get()
+            }
         }
 
         if (deprecatedTrait != null) {

--- a/smithy-swift-codegen/src/test/kotlin/SensitiveTraitGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/SensitiveTraitGeneratorTests.kt
@@ -8,21 +8,6 @@ import software.amazon.smithy.build.MockManifest
 import software.amazon.smithy.swift.codegen.SwiftCodegenPlugin
 
 class SensitiveTraitGeneratorTests {
-    @Test
-    fun `SensitiveTraitInRequestInput+CustomDebugStringConvertible`() {
-        val manifest = setupTest()
-        var extensionWithSensitiveTrait = manifest
-            .getFileString("example/models/SensitiveTraitInRequestInput+CustomDebugStringConvertible.swift").get()
-        extensionWithSensitiveTrait.shouldSyntacticSanityCheck()
-        val expectedContents =
-            """
-            extension SensitiveTraitInRequestInput: Swift.CustomDebugStringConvertible {
-                public var debugDescription: Swift.String {
-                    "SensitiveTraitInRequestInput(foo: \(Swift.String(describing: foo)), baz: \"CONTENT_REDACTED\")"}
-            }
-            """.trimIndent()
-        extensionWithSensitiveTrait.shouldContainOnlyOnce(expectedContents)
-    }
 
     @Test
     fun `SensitiveTraitInRequestOutput+CustomDebugStringConvertible`() {
@@ -36,22 +21,6 @@ class SensitiveTraitGeneratorTests {
                 public var debugDescription: Swift.String {
                     "CONTENT_REDACTED"
                 }
-            }
-            """.trimIndent()
-        extensionWithSensitiveTrait.shouldContainOnlyOnce(expectedContents)
-    }
-
-    @Test
-    fun `AllSensitiveMemberStruct+CustomDebugStringConvertible`() {
-        val manifest = setupTest()
-        var extensionWithSensitiveTrait = manifest
-            .getFileString("example/models/SensitiveTraitTestRequestOutputResponse+CustomDebugStringConvertible.swift").get()
-        extensionWithSensitiveTrait.shouldSyntacticSanityCheck()
-        val expectedContents =
-            """
-            extension SensitiveTraitTestRequestOutputResponse: Swift.CustomDebugStringConvertible {
-                public var debugDescription: Swift.String {
-                    "SensitiveTraitTestRequestOutputResponse(bar: \"CONTENT_REDACTED\", baz: \"CONTENT_REDACTED\", foo: \"CONTENT_REDACTED\")"}
             }
             """.trimIndent()
         extensionWithSensitiveTrait.shouldContainOnlyOnce(expectedContents)

--- a/smithy-swift-codegen/src/test/resources/sensitive-trait-test.smithy
+++ b/smithy-swift-codegen/src/test/resources/sensitive-trait-test.smithy
@@ -29,7 +29,6 @@ operation SensitiveTraitTestRequest {
 }
 
 structure SensitiveTraitInRequestInput {
-    @sensitive
     baz: String,
     foo: String
 }
@@ -46,10 +45,7 @@ structure SensitiveTraitTestRequestInput {
 }
 
 structure SensitiveTraitTestRequestOutput {
-   @sensitive
    foo: String,
-   @sensitive
    bar: String,
-   @sensitive
-   baz: String
+   baz: String,
 }


### PR DESCRIPTION
This change is to make some minor adjustments in preparation for the 2.0 release. In particular, there were some `@deprecated` traits added to the prelude that we will ignore for now. Also made some changes to be able to use 1.22 were some braking changes were made about the `@sensitive` trait that now needs to be applied to shapes instead of to individual members of them.<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.