### PR TITLE
Update smithy version to 1.23.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ kotlin.code.style=official
 # config
 
 # codegen
-smithyVersion=1.22.0
+smithyVersion=1.23.0
 smithyGradleVersion=0.6.0
 
 # kotlin

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ShapeValueGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ShapeValueGenerator.kt
@@ -190,6 +190,11 @@ class ShapeValueGenerator(
                     ")!"
                 } else { "" }
             }
+            ShapeType.ENUM -> {
+                val symbol = symbolProvider.toSymbol(shape)
+                writer.writeInline("\$N(rawValue: ", symbol)
+                ")!"
+            }
             ShapeType.BLOB -> {
                 if (shape.hasTrait<StreamingTrait>()) {
                     writer.writeInline("ByteStream.from(data: ")
@@ -319,7 +324,7 @@ class ShapeValueGenerator(
                     writer.writeInline("Date(timeIntervalSince1970: \$L)", node.value)
                 }
 
-                ShapeType.BYTE, ShapeType.SHORT, ShapeType.INTEGER,
+                ShapeType.BYTE, ShapeType.SHORT, ShapeType.INTEGER, ShapeType.INT_ENUM,
                 ShapeType.LONG, ShapeType.DOUBLE, ShapeType.FLOAT -> writer.writeInline("\$L", node.value)
 
                 /*

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftWriter.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftWriter.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.codegen.core.SymbolDependency
 import software.amazon.smithy.codegen.core.SymbolDependencyContainer
 import software.amazon.smithy.codegen.core.SymbolReference
 import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.loader.Prelude
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.traits.DeprecatedTrait
@@ -212,7 +213,13 @@ class SwiftWriter(private val fullPackageName: String) : CodeWriter() {
         if (shape.getTrait(DeprecatedTrait::class.java).isPresent) {
             deprecatedTrait = shape.getTrait(DeprecatedTrait::class.java).get()
         } else if (shape.getMemberTrait(model, DeprecatedTrait::class.java).isPresent) {
-            deprecatedTrait = shape.getMemberTrait(model, DeprecatedTrait::class.java).get()
+            if (shape is MemberShape) {
+                if (!Prelude.isPreludeShape(shape.getTarget())) {
+                    deprecatedTrait = shape.getMemberTrait(model, DeprecatedTrait::class.java).get()
+                }
+            } else {
+                deprecatedTrait = shape.getMemberTrait(model, DeprecatedTrait::class.java).get()
+            }
         }
 
         if (deprecatedTrait != null) {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/HttpResponseHeaders.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/HttpResponseHeaders.kt
@@ -188,6 +188,7 @@ class HttpResponseHeaders(
         ShapeType.BYTE -> "${SwiftTypes.Int8}($stringValue) ?? 0"
         ShapeType.SHORT -> "${SwiftTypes.Int16}($stringValue) ?? 0"
         ShapeType.INTEGER -> "${SwiftTypes.Int}($stringValue) ?? 0"
+        ShapeType.INT_ENUM -> "${SwiftTypes.Int}($stringValue) ?? 0"
         ShapeType.LONG -> "${SwiftTypes.Int}($stringValue) ?? 0"
         ShapeType.FLOAT -> "${SwiftTypes.Float}($stringValue) ?? 0"
         ShapeType.DOUBLE -> "${SwiftTypes.Double}($stringValue) ?? 0"

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/bindingTraits/HttpResponseTraitWithHttpPayload.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/bindingTraits/HttpResponseTraitWithHttpPayload.kt
@@ -54,6 +54,13 @@ class HttpResponseTraitWithHttpPayload(
                     writer.indent()
                     writer.write("self.\$L = nil", memberName).closeBlock("}")
                 }
+                ShapeType.ENUM -> {
+                    writer.openBlock("if let output = \$N(data: data, encoding: .utf8) {", "} else {", SwiftTypes.String) {
+                        writer.write("self.\$L = \$L(rawValue: output)", memberName, symbol)
+                    }
+                    writer.indent()
+                    writer.write("self.\$L = nil", memberName).closeBlock("}")
+                }
                 ShapeType.BLOB -> {
                     writer.write("self.\$L = data", memberName)
                 }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/handlers/HttpBodyMiddleware.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/handlers/HttpBodyMiddleware.kt
@@ -95,6 +95,13 @@ class HttpBodyMiddleware(
                     renderEncodedBodyAddedToRequest(bodyDeclaration, dataDeclaration)
                 }
             }
+            ShapeType.ENUM -> {
+                val contents = "$memberName.rawValue"
+                writer.openBlock("if let $memberName = input.operationInput.$memberName {", "}") {
+                    writer.write("let $dataDeclaration = \$L.data(using: .utf8)", contents)
+                    renderEncodedBodyAddedToRequest(bodyDeclaration, dataDeclaration)
+                }
+            }
             ShapeType.STRUCTURE, ShapeType.UNION -> {
                 // delegate to the member encode function
                 writer.openBlock("do {", "} catch let err {") {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/MemberShapeEncodeGeneratable.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/MemberShapeEncodeGeneratable.kt
@@ -14,7 +14,7 @@ interface MemberShapeEncodeGeneratable {
 class MemberShapeEncodeConstants {
     companion object {
         val primitiveSymbols: MutableSet<ShapeType> = hashSetOf(
-            ShapeType.INTEGER, ShapeType.BYTE, ShapeType.SHORT,
+            ShapeType.INTEGER, ShapeType.INT_ENUM, ShapeType.BYTE, ShapeType.SHORT,
             ShapeType.LONG, ShapeType.FLOAT, ShapeType.DOUBLE, ShapeType.BOOLEAN
         )
         val floatingPointPrimitiveSymbols: MutableSet <ShapeType> = hashSetOf(

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeEncodeGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeEncodeGenerator.kt
@@ -251,7 +251,7 @@ abstract class MemberShapeEncodeGenerator(
             }
         } else {
             val primitiveSymbols: MutableSet<ShapeType> = hashSetOf(
-                ShapeType.INTEGER, ShapeType.BYTE, ShapeType.SHORT,
+                ShapeType.INTEGER, ShapeType.INT_ENUM, ShapeType.BYTE, ShapeType.SHORT,
                 ShapeType.LONG, ShapeType.FLOAT, ShapeType.DOUBLE, ShapeType.BOOLEAN
             )
             if (primitiveSymbols.contains(target.type)) {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/NestedShapeTransformer.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/NestedShapeTransformer.kt
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.swift.codegen.model
 
+import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.ShapeType
@@ -14,6 +15,9 @@ import software.amazon.smithy.swift.codegen.customtraits.NestedTrait
 object NestedShapeTransformer {
     fun transform(model: Model, service: ServiceShape): Model {
         val next = transformInner(model, service)
+        if (next == model) {
+            throw CodegenException("model ${model} is equal to ${next}, loop detected")
+        }
         return if (next == null) {
             model
         } else {
@@ -35,6 +39,7 @@ object NestedShapeTransformer {
                     ShapeType.STRUCTURE -> shape.asStructureShape().get().toBuilder().addTrait(NestedTrait()).build()
                     ShapeType.UNION -> shape.asUnionShape().get().toBuilder().addTrait(NestedTrait()).build()
                     ShapeType.STRING -> shape.asStringShape().get().toBuilder().addTrait(NestedTrait()).build()
+                    ShapeType.ENUM -> shape.asEnumShape().get().toBuilder().addTrait(NestedTrait()).build()
                     else -> shape
                 }
             } else {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/ShapeExt.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/ShapeExt.kt
@@ -113,6 +113,6 @@ fun ServiceShape.nestedNamespaceType(symbolProvider: SymbolProvider): Symbol {
 
 fun Model.getNestedShapes(serviceShape: ServiceShape): Set<Shape> {
     return Selector
-        .parse("service [id=${serviceShape.id }] ~> :is(structure,union, string [trait|enum]) :not(<-[input, output, error]-)")
+        .parse("service [id=${serviceShape.id }] ~> :is(structure, union, string [trait|enum]) :not(<-[input, output, error]-)")
         .select(this)
 }


### PR DESCRIPTION
Update Smithy version to 1.23.0 to pick up the IDL-2.0 Changes. 
<!--- Provide a general summary of your changes in the Title above -->

## Description of changes
This changes updates the version of Smithy to 1.23.0. Given the changes that this release brings there are some shapes in the prelude that are now `@deprected`, to avoid creating any changes to the code generation we will skip adding the `available` attributer if the target of the members is a shape in the prelude. This should keep the generated code the same.

<!--- Why is this change required? What problem does it solve? -->


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.