### PR TITLE
fix: use self to disambiguate between member and encoder param

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeEncodeGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeEncodeGenerator.kt
@@ -246,7 +246,7 @@ abstract class MemberShapeEncodeGenerator(
         val isBoxed = symbol.isBoxed()
         val memberWithExtension = getShapeExtension(member, memberName, isBoxed, true)
         if (isBoxed) {
-            writer.openBlock("if let $memberName = $memberName {", "}") {
+            writer.openBlock("if let $memberName = self.$memberName {", "}") {
                 writer.write("try $containerName.encode($memberWithExtension, forKey: .\$L)", memberName)
             }
         } else {

--- a/smithy-swift-codegen/src/test/kotlin/ServiceRenamesTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/ServiceRenamesTests.kt
@@ -148,7 +148,7 @@ class ServiceRenamesTests {
             
                 public func encode(to encoder: Swift.Encoder) throws {
                     var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
-                    if let salutation = salutation {
+                    if let salutation = self.salutation {
                         try encodeContainer.encode(salutation, forKey: .salutation)
                     }
                 }

--- a/smithy-swift-codegen/src/test/kotlin/StructDecodeGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/StructDecodeGenerationTests.kt
@@ -101,7 +101,7 @@ class StructDecodeGenerationTests {
                             try intMapContainer.encode(intmap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
                         }
                     }
-                    if let member1 = member1 {
+                    if let member1 = self.member1 {
                         try encodeContainer.encode(member1, forKey: .member1)
                     }
                     if let stringMap = stringMap {
@@ -475,10 +475,10 @@ extension NestedShapesOutputResponseBody: Swift.Decodable {
             
                 public func encode(to encoder: Swift.Encoder) throws {
                     var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
-                    if let foo = foo {
+                    if let foo = self.foo {
                         try encodeContainer.encode(foo, forKey: .foo)
                     }
-                    if let nested = nested {
+                    if let nested = self.nested {
                         try encodeContainer.encode(nested.value, forKey: .nested)
                     }
                 }
@@ -513,10 +513,10 @@ extension NestedShapesOutputResponseBody: Swift.Decodable {
             
                 public func encode(to encoder: Swift.Encoder) throws {
                     var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
-                    if let bar = bar {
+                    if let bar = self.bar {
                         try encodeContainer.encode(bar, forKey: .bar)
                     }
-                    if let recursiveMember = recursiveMember {
+                    if let recursiveMember = self.recursiveMember {
                         try encodeContainer.encode(recursiveMember, forKey: .recursiveMember)
                     }
                 }

--- a/smithy-swift-codegen/src/test/kotlin/StructEncodeGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/StructEncodeGenerationTests.kt
@@ -52,13 +52,13 @@ class StructEncodeGenerationTests {
             
                 public func encode(to encoder: Swift.Encoder) throws {
                     var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
-                    if let payload1 = payload1 {
+                    if let payload1 = self.payload1 {
                         try encodeContainer.encode(payload1, forKey: .payload1)
                     }
-                    if let payload2 = payload2 {
+                    if let payload2 = self.payload2 {
                         try encodeContainer.encode(payload2, forKey: .payload2)
                     }
-                    if let payload3 = payload3 {
+                    if let payload3 = self.payload3 {
                         try encodeContainer.encode(payload3, forKey: .payload3)
                     }
                 }
@@ -95,7 +95,7 @@ class StructEncodeGenerationTests {
                             try intMapContainer.encode(intmap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
                         }
                     }
-                    if let member1 = member1 {
+                    if let member1 = self.member1 {
                         try encodeContainer.encode(member1, forKey: .member1)
                     }
                     if let stringMap = stringMap {
@@ -173,16 +173,16 @@ class StructEncodeGenerationTests {
             
                 public func encode(to encoder: Swift.Encoder) throws {
                     var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
-                    if let dateTime = dateTime {
+                    if let dateTime = self.dateTime {
                         try encodeContainer.encode(dateTime.iso8601WithoutFractionalSeconds(), forKey: .dateTime)
                     }
-                    if let epochSeconds = epochSeconds {
+                    if let epochSeconds = self.epochSeconds {
                         try encodeContainer.encode(epochSeconds.timeIntervalSince1970, forKey: .epochSeconds)
                     }
-                    if let httpDate = httpDate {
+                    if let httpDate = self.httpDate {
                         try encodeContainer.encode(httpDate.rfc5322(), forKey: .httpDate)
                     }
-                    if let normal = normal {
+                    if let normal = self.normal {
                         try encodeContainer.encode(normal.iso8601WithoutFractionalSeconds(), forKey: .normal)
                     }
                     if let timestampList = timestampList {
@@ -263,7 +263,7 @@ class StructEncodeGenerationTests {
             
                 public func encode(to encoder: Swift.Encoder) throws {
                     var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
-                    if let nestedWithEnum = nestedWithEnum {
+                    if let nestedWithEnum = self.nestedWithEnum {
                         try encodeContainer.encode(nestedWithEnum, forKey: .nestedWithEnum)
                     }
                 }
@@ -282,7 +282,7 @@ class StructEncodeGenerationTests {
             
                 public func encode(to encoder: Swift.Encoder) throws {
                     var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
-                    if let myEnum = myEnum {
+                    if let myEnum = self.myEnum {
                         try encodeContainer.encode(myEnum.rawValue, forKey: .myEnum)
                     }
                 }
@@ -315,10 +315,10 @@ class StructEncodeGenerationTests {
             
                 public func encode(to encoder: Swift.Encoder) throws {
                     var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
-                    if let foo = foo {
+                    if let foo = self.foo {
                         try encodeContainer.encode(foo, forKey: .foo)
                     }
-                    if let nested = nested {
+                    if let nested = self.nested {
                         try encodeContainer.encode(nested.value, forKey: .nested)
                     }
                 }
@@ -353,10 +353,10 @@ class StructEncodeGenerationTests {
             
                 public func encode(to encoder: Swift.Encoder) throws {
                     var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
-                    if let bar = bar {
+                    if let bar = self.bar {
                         try encodeContainer.encode(bar, forKey: .bar)
                     }
-                    if let recursiveMember = recursiveMember {
+                    if let recursiveMember = self.recursiveMember {
                         try encodeContainer.encode(recursiveMember, forKey: .recursiveMember)
                     }
                 }
@@ -544,22 +544,22 @@ extension PrimitiveTypesInput: Swift.Encodable {
 
     public func encode(to encoder: Swift.Encoder) throws {
         var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
-        if let booleanVal = booleanVal {
+        if let booleanVal = self.booleanVal {
             try encodeContainer.encode(booleanVal, forKey: .booleanVal)
         }
-        if let byteVal = byteVal {
+        if let byteVal = self.byteVal {
             try encodeContainer.encode(byteVal, forKey: .byteVal)
         }
-        if let doubleVal = doubleVal {
+        if let doubleVal = self.doubleVal {
             try encodeContainer.encode(doubleVal, forKey: .doubleVal)
         }
-        if let floatVal = floatVal {
+        if let floatVal = self.floatVal {
             try encodeContainer.encode(floatVal, forKey: .floatVal)
         }
-        if let intVal = intVal {
+        if let intVal = self.intVal {
             try encodeContainer.encode(intVal, forKey: .intVal)
         }
-        if let longVal = longVal {
+        if let longVal = self.longVal {
             try encodeContainer.encode(longVal, forKey: .longVal)
         }
         if primitiveBooleanVal != false {
@@ -583,10 +583,10 @@ extension PrimitiveTypesInput: Swift.Encodable {
         if primitiveShortVal != 0 {
             try encodeContainer.encode(primitiveShortVal, forKey: .primitiveShortVal)
         }
-        if let shortVal = shortVal {
+        if let shortVal = self.shortVal {
             try encodeContainer.encode(shortVal, forKey: .shortVal)
         }
-        if let str = str {
+        if let str = self.str {
             try encodeContainer.encode(str, forKey: .str)
         }
     }

--- a/smithy-swift-codegen/src/test/kotlin/UnionEncodeGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/UnionEncodeGeneratorTests.kt
@@ -45,7 +45,7 @@ class UnionEncodeGeneratorTests {
             
                 public func encode(to encoder: Swift.Encoder) throws {
                     var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
-                    if let contents = contents {
+                    if let contents = self.contents {
                         try encodeContainer.encode(contents, forKey: .contents)
                     }
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-swift/issues/603

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

This change is required to unblock https://github.com/awslabs/aws-sdk-swift/pull/597 release. We need to look holistically to avoid this kind of conflict at other places where `Codable` and `Decodable` are implemented.

Before
```swift
extension IvsClientTypes.VideoConfiguration: Swift.Codable {
    enum CodingKeys: Swift.String, Swift.CodingKey {
        case avcLevel
        case avcProfile
        case codec
        case encoder
        case targetBitrate
        case targetFramerate
        case videoHeight
        case videoWidth
    }

    public func encode(to encoder: Swift.Encoder) throws {
        var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
        if let avcLevel = avcLevel {
            try encodeContainer.encode(avcLevel, forKey: .avcLevel)
        }
        if let avcProfile = avcProfile {
            try encodeContainer.encode(avcProfile, forKey: .avcProfile)
        }
        if let codec = codec {
            try encodeContainer.encode(codec, forKey: .codec)
        }
        if let encoder = encoder {
            try encodeContainer.encode(encoder, forKey: .encoder)
        }
        if targetBitrate != 0 {
            try encodeContainer.encode(targetBitrate, forKey: .targetBitrate)
        }
        if targetFramerate != 0 {
            try encodeContainer.encode(targetFramerate, forKey: .targetFramerate)
        }
        if videoHeight != 0 {
            try encodeContainer.encode(videoHeight, forKey: .videoHeight)
        }
        if videoWidth != 0 {
            try encodeContainer.encode(videoWidth, forKey: .videoWidth)
        }
    }
```

After
```swift
extension IvsClientTypes.VideoConfiguration: Swift.Codable {
    enum CodingKeys: Swift.String, Swift.CodingKey {
        case avcLevel
        case avcProfile
        case codec
        case encoder
        case targetBitrate
        case targetFramerate
        case videoHeight
        case videoWidth
    }

    public func encode(to encoder: Swift.Encoder) throws {
        var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
        if let avcLevel = self.avcLevel {
            try encodeContainer.encode(avcLevel, forKey: .avcLevel)
        }
        if let avcProfile = self.avcProfile {
            try encodeContainer.encode(avcProfile, forKey: .avcProfile)
        }
        if let codec = self.codec {
            try encodeContainer.encode(codec, forKey: .codec)
        }
        if let encoder = self.encoder {
            try encodeContainer.encode(encoder, forKey: .encoder)
        }
        if targetBitrate != 0 {
            try encodeContainer.encode(targetBitrate, forKey: .targetBitrate)
        }
        if targetFramerate != 0 {
            try encodeContainer.encode(targetFramerate, forKey: .targetFramerate)
        }
        if videoHeight != 0 {
            try encodeContainer.encode(videoHeight, forKey: .videoHeight)
        }
        if videoWidth != 0 {
            try encodeContainer.encode(videoWidth, forKey: .videoWidth)
        }
    }
```

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.