### PR TITLE
fix: convert map to array of entry for paginators

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PaginatorGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PaginatorGenerator.kt
@@ -6,11 +6,19 @@ import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.PaginatedIndex
 import software.amazon.smithy.model.knowledge.PaginationInfo
-import software.amazon.smithy.model.shapes.*
+import software.amazon.smithy.model.shapes.CollectionShape
+import software.amazon.smithy.model.shapes.MapShape
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.traits.PaginatedTrait
 import software.amazon.smithy.swift.codegen.core.CodegenContext
 import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
-import software.amazon.smithy.swift.codegen.model.*
+import software.amazon.smithy.swift.codegen.model.SymbolProperty
+import software.amazon.smithy.swift.codegen.model.camelCaseName
+import software.amazon.smithy.swift.codegen.model.expectShape
+import software.amazon.smithy.swift.codegen.model.hasTrait
+import software.amazon.smithy.swift.codegen.model.isBoxed
 import software.amazon.smithy.swift.codegen.utils.toCamelCase
 
 /**

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PaginatorGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PaginatorGenerator.kt
@@ -197,7 +197,6 @@ class PaginatorGenerator : SwiftIntegration {
             } else {
                 error("Unexpected shape type $itemSymbolShape")
             }
-
         }
     }
 }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SymbolVisitor.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SymbolVisitor.kt
@@ -176,7 +176,10 @@ class SymbolVisitor(private val model: Model, swiftSettings: SwiftSettings) :
     override fun mapShape(shape: MapShape): Symbol {
         val reference = toSymbol(shape.value)
         val referenceTypeName = if (shape.hasTrait<SparseTrait>()) "$reference?" else "$reference"
-        return createSymbolBuilder(shape, "[${SwiftTypes.String}:$referenceTypeName]", true).addReference(reference).build()
+        return createSymbolBuilder(shape, "[${SwiftTypes.String}:$referenceTypeName]", true)
+            .addReference(reference)
+            .putProperty(SymbolProperty.ENTRY_EXPRESSION, "(String, $referenceTypeName)")
+            .build()
     }
 
     override fun setShape(shape: SetShape): Symbol {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/SymbolExt.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/SymbolExt.kt
@@ -15,6 +15,9 @@ import software.amazon.smithy.swift.codegen.removeSurroundingBackticks
  * Property bag keys used by symbol provider implementation
  */
 object SymbolProperty {
+    // Entry type for Maps
+    const val ENTRY_EXPRESSION: String = "entryExpression"
+
     // The key that holds the default value for a type (symbol) as a string
     const val DEFAULT_VALUE_KEY: String = "defaultValue"
 

--- a/smithy-swift-codegen/src/test/kotlin/PaginatorGeneratorTest.kt
+++ b/smithy-swift-codegen/src/test/kotlin/PaginatorGeneratorTest.kt
@@ -113,8 +113,8 @@ class PaginatorGeneratorTest {
         }
         
         /// This paginator transforms the `AsyncSequence` returned by `paginatedMapPaginated`
-        /// to access the nested member `[Swift.String:Swift.Int]`
-        /// - Returns: `[Swift.String:Swift.Int]`
+        /// to access the nested member `[(String, Swift.Int)]`
+        /// - Returns: `[(String, Swift.Int)]`
         extension PaginatorSequence where Input == PaginatedMapInput, Output == PaginatedMapOutputResponse {
             public func mapItems() async throws -> [(String, Swift.Int)] {
                 return try await self.asyncCompactMap { item in item.inner?.mapItems?.map { (${'$'}0, ${'$'}1) } }

--- a/smithy-swift-codegen/src/test/kotlin/PaginatorGeneratorTest.kt
+++ b/smithy-swift-codegen/src/test/kotlin/PaginatorGeneratorTest.kt
@@ -76,7 +76,7 @@ class PaginatorGeneratorTest {
         /// to access the nested member `[TestClientTypes.FunctionConfiguration]`
         /// - Returns: `[TestClientTypes.FunctionConfiguration]`
         extension PaginatorSequence where Input == ListFunctionsInput, Output == ListFunctionsOutputResponse {
-            func functions() async throws -> [TestClientTypes.FunctionConfiguration] {
+            public func functions() async throws -> [TestClientTypes.FunctionConfiguration] {
                 return try await self.asyncCompactMap { item in item.functions }
             }
         }
@@ -116,8 +116,8 @@ class PaginatorGeneratorTest {
         /// to access the nested member `[Swift.String:Swift.Int]`
         /// - Returns: `[Swift.String:Swift.Int]`
         extension PaginatorSequence where Input == PaginatedMapInput, Output == PaginatedMapOutputResponse {
-            func mapItems() async throws -> [Swift.String:Swift.Int] {
-                return try await self.asyncCompactMap { item in item.inner?.mapItems }
+            public func mapItems() async throws -> [(String, Swift.Int)] {
+                return try await self.asyncCompactMap { item in item.inner?.mapItems?.map { (${'$'}0, ${'$'}1) } }
             }
         }
         """.trimIndent()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-swift/issues/606
https://github.com/awslabs/aws-sdk-swift/issues/605

## Description of changes
This change addresses two problems
1. When pagination nested property is map instead of array. Currently, the SDK fails to compile https://github.com/awslabs/aws-sdk-swift/issues/606 Ex. APIGateway service. With this change, the nested map property is converted to array of (Key, Value) pair. This change is similar to Kotlin implementation [here](https://github.com/awslabs/smithy-kotlin/blob/910b61368ad126c2f751b3df79253530153aff6c/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/rendering/PaginatorGenerator.kt#L251)
2. The nested pagination property by design is accessible to public which it is not currently, this change makes it public. 


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.