### PR TITLE
fix: skip the deprecated trait only for shapes in the prelude

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ kotlin.code.style=official
 # config
 
 # codegen
-smithyVersion=1.23.0
+smithyVersion=[1.24.0,1.25.0[
 smithyGradleVersion=0.6.0
 
 # kotlin

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftWriter.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftWriter.kt
@@ -214,7 +214,7 @@ class SwiftWriter(private val fullPackageName: String) : CodeWriter() {
             deprecatedTrait = shape.getTrait(DeprecatedTrait::class.java).get()
         } else if (shape.getMemberTrait(model, DeprecatedTrait::class.java).isPresent) {
             if (shape is MemberShape) {
-                if (!Prelude.isPreludeShape(shape.getTarget())) {
+                if (isTargetDeprecated(model, shape)) {
                     deprecatedTrait = shape.getMemberTrait(model, DeprecatedTrait::class.java).get()
                 }
             } else {
@@ -259,5 +259,11 @@ class SwiftWriter(private val fullPackageName: String) : CodeWriter() {
         enumDefinition.documentation.ifPresent {
             writeDocs(it)
         }
+    }
+
+    private fun isTargetDeprecated(model: Model?, member: MemberShape): Boolean {
+        return model != null &&
+            model.expectShape(member.target).getTrait(DeprecatedTrait::class.java).isPresent &&
+            !Prelude.isPreludeShape(member.target)
     }
 }


### PR DESCRIPTION
## Description of changes
Some SDK inherit the deprecated traits from members, we should only skip them for deprecated shapes in the prelude. 
This change aligns this logic with the same logic used in [smithy-typescript](https://github.com/awslabs/smithy-typescript/blob/main/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptWriter.java#L277-L281).


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.