### PR TITLE
chore: add unit tests for IDL-2.0 enum shapes code generation

### DIFF
--- a/smithy-swift-codegen/src/test/resources/enum-shape-test.smithy
+++ b/smithy-swift-codegen/src/test/resources/enum-shape-test.smithy
@@ -1,0 +1,26 @@
+$version: "2.0"
+
+namespace smithy.example
+
+service Example {
+    version: "1.0.0"
+    operations: [
+        ChangeCard
+    ]
+}
+
+operation ChangeCard {
+    input: Card
+    output: Card
+}
+
+structure Card {
+    suit: Suit
+}
+
+enum Suit {
+    DIAMOND
+    CLUB
+    HEART
+    SPADE
+}


### PR DESCRIPTION

## Description of changes
Adds a unit test that tests that we generate code correctly using the `enum` shape from IDL-2.0. This test complements the [previous pull request](https://github.com/awslabs/smithy-swift/pull/432) that added logic to support enum shapes from IDL-2.0.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.