### PR TITLE
fix: use default value when deserializing non-optional members

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeDecodeGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeDecodeGenerator.kt
@@ -69,9 +69,9 @@ abstract class MemberShapeDecodeGenerator(
         val decodedMemberName = "${memberName}Decoded"
 
         // no need to assign nil to a member that is optional
-        val defaultValueLiteral = if (defaultValue != null && defaultValue != "nil") "?? $defaultValue" else ""
+        val defaultValueLiteral = if (defaultValue != null && defaultValue != "nil") " ?? $defaultValue" else ""
 
-        writer.write("let \$L = try \$L.$decodeVerb(\$N.self, forKey: .\$L) $defaultValueLiteral", decodedMemberName, containerName, symbol, memberName)
+        writer.write("let \$L = try \$L.$decodeVerb(\$N.self, forKey: .\$L)$defaultValueLiteral", decodedMemberName, containerName, symbol, memberName)
         renderAssigningDecodedMember(member, decodedMemberName)
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
fixes https://github.com/awslabs/aws-sdk-swift/issues/564
fixes https://github.com/awslabs/aws-sdk-swift/issues/611

## Description of changes

Codegen uses default values to generate the init for non-optional values eg. https://github.com/awslabs/aws-sdk-swift/blob/0.2.6/release/AWSSecretsManager/models/Models.swift#L4148 but while doing the deserialization, the member is considered as always present which is not true in service like AWSSecretsManager.

This change uses the the same default value is available to set the member when the response doesn't contain the field. To generate less code, codegen skips assigning `nil`.

Before
```swift
let rotationEnabledDecoded = try containerValues.decode(Swift.Bool.self, forKey: .rotationEnabled)
rotationEnabled = rotationEnabledDecoded
```
After
```swift
let rotationEnabledDecoded = try containerValues.decodeIfPresent(Swift.Bool.self, forKey: .rotationEnabled) ?? false
rotationEnabled = rotationEnabledDecoded
```

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.