### PR TITLE
fix: properly check if a member can be nullable

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ kotlin.code.style=official
 # config
 
 # codegen
-smithyVersion=1.23.0
+smithyVersion=[1.25.0,1.26.0[
 smithyGradleVersion=0.6.0
 
 # kotlin

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
@@ -63,7 +63,7 @@ fun writePackageManifest(settings: SwiftSettings, fileManifest: FileManifest, de
         }
     }
 
-    writer.write("let isUsingSPMLocal: Bool = FileManager.default.fileExists(atPath: \"${Resources.computeAbsolutePath("smithy-swift/Packages", "Packages", "SMITHY_SWIFT_CI_DIR")}/Packages/Package.swift\")")
+    writer.write("let isUsingSPMLocal: Bool = FileManager.default.fileExists(atPath: \"${Resources.computeAbsolutePath("smithy-swift", "", "SMITHY_SWIFT_CI_DIR")}/Package.swift\")")
     writer.openBlock("if isUsingSPMLocal {", "}") {
         renderPackageDependenciesWithLocalPaths(writer, distinctDependencies)
     }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDelegator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDelegator.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.codegen.core.SymbolReference
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
+import software.amazon.smithy.swift.codegen.model.SymbolProperty
 import software.amazon.smithy.swift.codegen.model.defaultValue
 import software.amazon.smithy.swift.codegen.model.isBoxed
 import software.amazon.smithy.utils.CodeWriter
@@ -100,7 +101,7 @@ class SwiftDelegator(
         val extensionSymbol = Symbol.builder()
             .name("${symbol.name}")
             .definitionFile("${symbol.definitionFile.replace(".swift", "+$extensionName.swift")}")
-            .putProperty("boxed", symbol.isBoxed())
+            .putProperty(SymbolProperty.BOXED_KEY, symbol.isBoxed())
             .putProperty("defaultValue", symbol.defaultValue())
             .build()
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDependency.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDependency.kt
@@ -24,7 +24,7 @@ enum class SwiftDependency(
         "main",
         "0.1.0",
         "https://github.com/awslabs/smithy-swift",
-        Resources.computeAbsolutePath("smithy-swift/Packages", "Packages", "SMITHY_SWIFT_CI_DIR") + "/Packages",
+        Resources.computeAbsolutePath("smithy-swift", "", "SMITHY_SWIFT_CI_DIR"),
         "ClientRuntime"
     ),
     XCTest("XCTest", null, "", "", "", ""),
@@ -33,7 +33,7 @@ enum class SwiftDependency(
         "main",
         "0.1.0",
         "https://github.com/awslabs/smithy-swift",
-        Resources.computeAbsolutePath("smithy-swift/Packages", "Packages", "SMITHY_SWIFT_CI_DIR") + "/Packages",
+        Resources.computeAbsolutePath("smithy-swift", "", "SMITHY_SWIFT_CI_DIR"),
         "ClientRuntime"
     );
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
@@ -147,7 +147,7 @@ fun renderMemberAssertions(writer: SwiftWriter, test: HttpMessageTestCase, membe
         } else if ((shape.isDoubleShape || shape.isFloatShape)) {
             val stringNodes = test.params.stringMap.values.map { it.asStringNode().getOrNull() }
             if (stringNodes.isNotEmpty() && stringNodes.mapNotNull { it?.value }.contains("NaN")) {
-                val suffix = if (symbolProvider.toSymbol(shape).isBoxed()) "?" else ""
+                val suffix = if (symbolProvider.toSymbol(member).isBoxed()) "?" else ""
                 writer.write("XCTAssertEqual(\$L$suffix.isNaN, \$L$suffix.isNaN)", expectedMemberName, actualMemberName)
             } else {
                 writer.write("XCTAssertEqual(\$L, \$L)", expectedMemberName, actualMemberName)

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/HttpResponseHeaders.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/HttpResponseHeaders.kt
@@ -38,7 +38,7 @@ class HttpResponseHeaders(
             val memberName = ctx.symbolProvider.toMemberName(hdrBinding.member)
             val headerName = hdrBinding.locationName
             val headerDeclaration = "${memberName}HeaderValue"
-            val isBoxed = ctx.symbolProvider.toSymbol(memberTarget).isBoxed()
+            val isBoxed = ctx.symbolProvider.toSymbol(hdrBinding.member).isBoxed()
             writer.write("if let $headerDeclaration = httpResponse.headers.value(for: \$S) {", headerName)
             writer.indent()
             when (memberTarget) {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/providers/HttpUrlPathProvider.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/providers/HttpUrlPathProvider.kt
@@ -90,6 +90,10 @@ class HttpUrlPathProvider(
                         "$labelMemberName$enumRawValueSuffix$percentEncoded"
                     }
                     ShapeType.FLOAT, ShapeType.DOUBLE -> "$labelMemberName.encoded()"
+                    ShapeType.ENUM -> {
+                        val percentEncoded = if (!it.isGreedyLabel) ".urlPercentEncoding()" else ""
+                        "$labelMemberName.rawValue$percentEncoded"
+                    }
                     else -> labelMemberName
                 }
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/providers/HttpUrlPathProvider.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/providers/HttpUrlPathProvider.kt
@@ -92,10 +92,13 @@ class HttpUrlPathProvider(
                     ShapeType.FLOAT, ShapeType.DOUBLE -> "$labelMemberName.encoded()"
                     else -> labelMemberName
                 }
-                val isBoxed = ctx.symbolProvider.toSymbol(targetShape).isBoxed()
+
+                // use member symbol to determine if we need to box the value
+                // similar to how struct is generated
+                val symbol = ctx.symbolProvider.toSymbol(binding.member)
 
                 // unwrap the label members if boxed
-                if (isBoxed) {
+                if (symbol.isBoxed()) {
                     writer.openBlock("guard let $labelMemberName = $labelMemberName else {", "}") {
                         writer.write("return nil")
                     }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/formurl/MemberShapeEncodeFormURLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/formurl/MemberShapeEncodeFormURLGenerator.kt
@@ -65,7 +65,7 @@ abstract class MemberShapeEncodeFormURLGenerator(
         writer.openBlock("for (index$level, $nestedMemberTargetName) in $memberName.enumerated() {", "}") {
             when (nestedMemberTarget) {
                 is CollectionShape -> {
-                    val isBoxed = ctx.symbolProvider.toSymbol(nestedMemberTarget).isBoxed()
+                    val isBoxed = ctx.symbolProvider.toSymbol(memberTarget.member).isBoxed()
                     if (isBoxed && !(nestedMemberTarget is SetShape)) {
                         writer.openBlock("if let $nestedMemberTargetName = $nestedMemberTargetName {", "}") {
                             renderNestedListEntryMember(nestedMemberTargetName, nestedMemberTarget, nestedMember, nestedMemberResolvedName, containerName, level)
@@ -119,7 +119,7 @@ abstract class MemberShapeEncodeFormURLGenerator(
         writer.openBlock("for (index$level, $nestedMemberTargetName) in $memberName.enumerated() {", "}") {
             when (nestedMemberTarget) {
                 is CollectionShape -> {
-                    val isBoxed = ctx.symbolProvider.toSymbol(nestedMemberTarget).isBoxed()
+                    val isBoxed = ctx.symbolProvider.toSymbol(memberTarget.member).isBoxed()
                     if (isBoxed && !(nestedMemberTarget is SetShape)) {
                         writer.openBlock("if let $nestedMemberTargetName = $nestedMemberTargetName {", "}") {
                             renderFlattenedListContainer(nestedMemberTargetName, nestedMemberTarget, nestedMember, memberName, member, containerName, level)
@@ -360,7 +360,7 @@ abstract class MemberShapeEncodeFormURLGenerator(
     }
 
     fun renderScalarMember(member: MemberShape, memberTarget: Shape, containerName: String) {
-        val symbol = ctx.symbolProvider.toSymbol(memberTarget)
+        val symbol = ctx.symbolProvider.toSymbol(member)
         val memberName = ctx.symbolProvider.toMemberName(member)
         val resolvedMemberName = customizations.customNameTraitGenerator(member, member.memberName)
         val isBoxed = symbol.isBoxed()

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeEncodeGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeEncodeGenerator.kt
@@ -4,6 +4,7 @@
  */
 package software.amazon.smithy.swift.codegen.integration.serde.json
 
+import software.amazon.smithy.model.knowledge.NullableIndex
 import software.amazon.smithy.model.shapes.BlobShape
 import software.amazon.smithy.model.shapes.CollectionShape
 import software.amazon.smithy.model.shapes.MapShape
@@ -37,6 +38,8 @@ abstract class MemberShapeEncodeGenerator(
 ) : MemberShapeEncodeGeneratable {
 
     private val dictKey = "dictKey"
+    private val nullableIndex = NullableIndex.of(ctx.model)
+
     /*
      Add custom extensions to be rendered to handle optional shapes and
      special types like enum, timestamp, blob
@@ -241,7 +244,7 @@ abstract class MemberShapeEncodeGenerator(
         containerName: String,
         httpPayloadTraitNotOnAnyMember: Boolean = false
     ) {
-        val symbol = ctx.symbolProvider.toSymbol(target)
+        val symbol = ctx.symbolProvider.toSymbol(member)
         val memberName = ctx.symbolProvider.toMemberName(member)
         val isBoxed = symbol.isBoxed()
         val memberWithExtension = getShapeExtension(member, memberName, isBoxed, true)
@@ -269,7 +272,7 @@ abstract class MemberShapeEncodeGenerator(
         member: MemberShape,
         containerName: String
     ) {
-        val symbol = ctx.symbolProvider.toSymbol(target)
+        val symbol = ctx.symbolProvider.toSymbol(member)
         val memberName = ctx.symbolProvider.toMemberName(member)
         val isBoxed = symbol.isBoxed()
         val memberWithExtension = getShapeExtension(member, memberName, isBoxed, true)

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/UnionDecodeGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/UnionDecodeGenerator.kt
@@ -30,7 +30,7 @@ class UnionDecodeGenerator(
                     is CollectionShape -> renderDecodeListMember(target, memberName, containerName, member, member)
                     is MapShape -> renderDecodeMapMember(target, memberName, containerName, member)
                     is TimestampShape -> renderDecodeForTimestamp(ctx, target, member, containerName)
-                    else -> writeDecodeForPrimitive(target, member, containerName)
+                    else -> writeDecodeForPrimitive(target, member, containerName, ignoreDefaultValues = true)
                 }
             }
             writer.write("self = .sdkUnknown(\"\")")

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeDecodeXMLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeDecodeXMLGenerator.kt
@@ -133,7 +133,7 @@ abstract class MemberShapeDecodeXMLGenerator(
 
     private fun renderNestedListMemberTarget(memberTarget: CollectionShape, containerName: String, memberBuffer: String, level: Int) {
         val nestedMemberTarget = ctx.model.expectShape(memberTarget.member.target)
-        val nestedMemberTargetIsBoxed = ctx.symbolProvider.toSymbol(nestedMemberTarget).isBoxed() && memberTarget.hasTrait<SparseTrait>()
+        val nestedMemberTargetIsBoxed = ctx.symbolProvider.toSymbol(memberTarget.member).isBoxed() && memberTarget.hasTrait<SparseTrait>()
 
         val isSetShape = memberTarget is SetShape
 
@@ -150,7 +150,7 @@ abstract class MemberShapeDecodeXMLGenerator(
 
     fun renderMapMember(member: MemberShape, memberTarget: MapShape, containerName: String, memberName: String) {
         val memberTargetValue = ctx.symbolProvider.toSymbol(memberTarget.value)
-        val symbolOptional = if (ctx.symbolProvider.toSymbol(memberTarget).isBoxed()) "?" else ""
+        val symbolOptional = if (ctx.symbolProvider.toSymbol(member).isBoxed()) "?" else ""
 
         val memberNameUnquoted = memberName.removeSurrounding("`", "`")
         var currContainerName = containerName
@@ -236,7 +236,7 @@ abstract class MemberShapeDecodeXMLGenerator(
 
     open fun renderTimestampMember(member: MemberShape, memberTarget: TimestampShape, containerName: String) {
         val memberName = ctx.symbolProvider.toMemberName(member).removeSurrounding("`", "`")
-        var memberTargetSymbol = ctx.symbolProvider.toSymbol(memberTarget)
+        var memberTargetSymbol = ctx.symbolProvider.toSymbol(member)
         val decodeVerb = if (memberTargetSymbol.isBoxed()) "decodeIfPresent" else "decode"
         val decodedMemberName = "${memberName}Decoded"
         writer.write("let $decodedMemberName = try $containerName.$decodeVerb(\$N.self, forKey: .$memberName)", SwiftTypes.String)
@@ -282,7 +282,7 @@ abstract class MemberShapeDecodeXMLGenerator(
     fun renderScalarMember(member: MemberShape, memberTarget: Shape, containerName: String, unkeyed: Boolean = false, isUnion: Boolean = false) {
         val memberName = ctx.symbolProvider.toMemberName(member)
         val memberNameUnquoted = memberName.removeSurrounding("`", "`")
-        var memberTargetSymbol = ctx.symbolProvider.toSymbol(memberTarget)
+        var memberTargetSymbol = ctx.symbolProvider.toSymbol(member)
         if (member.hasTrait(SwiftBoxTrait::class.java)) {
             memberTargetSymbol = memberTargetSymbol.recursiveSymbol()
         }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeEncodeXMLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeEncodeXMLGenerator.kt
@@ -118,7 +118,7 @@ abstract class MemberShapeEncodeXMLGenerator(
         writer.openBlock("for $nestedMemberTargetName in $memberName {", "}") {
             when (nestedMemberTarget) {
                 is CollectionShape -> {
-                    val isBoxed = ctx.symbolProvider.toSymbol(nestedMemberTarget).isBoxed()
+                    val isBoxed = ctx.symbolProvider.toSymbol(memberTarget.member).isBoxed()
                     if (isBoxed && !(nestedMemberTarget is SetShape)) {
                         writer.openBlock("if let $nestedMemberTargetName = $nestedMemberTargetName {", "}") {
                             renderFlattenedListContainer(nestedMemberTargetName, nestedMemberTarget, nestedMember, memberName, member, containerName, level)
@@ -317,7 +317,7 @@ abstract class MemberShapeEncodeXMLGenerator(
     }
 
     fun renderScalarMember(member: MemberShape, memberTarget: Shape, containerName: String) {
-        val symbol = ctx.symbolProvider.toSymbol(memberTarget)
+        val symbol = ctx.symbolProvider.toSymbol(member)
         val originalMemberName = member.memberName
         val memberName = ctx.symbolProvider.toMemberName(member)
         val resolvedMemberName = XMLNameTraitGenerator.construct(member, originalMemberName).toString()

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/StructEncodeXMLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/StructEncodeXMLGenerator.kt
@@ -77,7 +77,7 @@ class StructEncodeXMLGenerator(
                 }
             }
             is TimestampShape -> {
-                val symbol = ctx.symbolProvider.toSymbol(memberTarget)
+                val symbol = ctx.symbolProvider.toSymbol(member)
                 val isBoxed = symbol.isBoxed()
                 if (isBoxed) {
                     writer.openBlock("if let $memberName = $memberName {", "}") {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/SymbolExt.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/SymbolExt.kt
@@ -44,8 +44,8 @@ fun Symbol.recursiveSymbol(): Symbol {
     return Symbol.builder()
         .addDependency(SwiftDependency.CLIENT_RUNTIME)
         .name("Box<$fullName>")
-        .putProperty("boxed", isBoxed())
-        .putProperty("defaultValue", defaultValue())
+        .putProperty(SymbolProperty.BOXED_KEY, isBoxed())
+        .putProperty(SymbolProperty.DEFAULT_VALUE_KEY, defaultValue())
         .build()
 }
 
@@ -65,8 +65,8 @@ fun Symbol.defaultValue(): String? {
 fun Symbol.bodySymbol(): Symbol {
     return Symbol.builder()
         .name("${name}Body")
-        .putProperty("boxed", isBoxed())
-        .putProperty("defaultValue", defaultValue())
+        .putProperty(SymbolProperty.BOXED_KEY, isBoxed())
+        .putProperty(SymbolProperty.DEFAULT_VALUE_KEY, defaultValue())
         .build()
 }
 

--- a/smithy-swift-codegen/src/test/kotlin/ServiceGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/ServiceGeneratorTests.kt
@@ -21,12 +21,12 @@ class ServiceGeneratorTests {
 
     init {
         var model = javaClass.getResource("service-generator-test-operations.smithy").asSmithy()
-        val provider: SymbolProvider = SwiftCodegenPlugin.createSymbolProvider(model, model.defaultSettings())
         val writer = SwiftWriter("test")
 
         val settings = model.defaultSettings()
         val manifest = MockManifest()
         model = AddOperationShapes.execute(model, settings.getService(model), settings.moduleName)
+        val provider: SymbolProvider = SwiftCodegenPlugin.createSymbolProvider(model, model.defaultSettings())
         val writers = SwiftDelegator(settings, model, manifest, provider)
         val generator = ServiceGenerator(settings, model, provider, writer, writers)
         generator.render()

--- a/smithy-swift-codegen/src/test/kotlin/StructureGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/StructureGeneratorTests.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.build.MockManifest
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.swift.codegen.StructureGenerator
 import software.amazon.smithy.swift.codegen.SwiftCodegenPlugin
@@ -20,12 +21,11 @@ import java.util.function.Consumer
 class StructureGeneratorTests {
     @Test
     fun `it renders non-error structures`() {
-
-        val struct: StructureShape = createStructureWithoutErrorTrait()
-        val model: Model = createModelWithStructureShape(struct)
+        val model = createModelWithStructureWithoutErrorTrait()
         val swiftSettings = model.defaultSettings()
         val provider: SymbolProvider = SwiftCodegenPlugin.createSymbolProvider(model, swiftSettings)
         val writer = SwiftWriter("MockPackage")
+        val struct = model.getShape(ShapeId.from("smithy.example#MyStruct")).get() as StructureShape
         val generator = StructureGenerator(model, provider, writer, struct, swiftSettings)
         generator.render()
 

--- a/smithy-swift-codegen/src/test/kotlin/TestUtils.kt
+++ b/smithy-swift-codegen/src/test/kotlin/TestUtils.kt
@@ -94,22 +94,17 @@ fun buildMockPluginContext(model: Model, manifest: FileManifest, serviceShapeId:
     return buildPluginContext(model, manifest, serviceShapeId, "example", "0.0.1")
 }
 
-// FIXME: use inline string modeling rather than the builder here
-fun createStructureWithoutErrorTrait(): StructureShape {
-    val member1 = MemberShape.builder().id("smithy.example#MyStruct\$foo").target("smithy.api#String").build()
-    val member2 = MemberShape.builder().id("smithy.example#MyStruct\$bar").target("smithy.api#PrimitiveInteger").build()
-    val member3 = MemberShape.builder().id("smithy.example#MyStruct\$baz")
-        .target("smithy.api#Integer")
-        .addTrait(DocumentationTrait("This *is* documentation about the member."))
-        .build()
-
-    return StructureShape.builder()
-        .id("smithy.example#MyStruct")
-        .addMember(member1)
-        .addMember(member2)
-        .addMember(member3)
-        .addTrait(DocumentationTrait("This *is* documentation about the shape."))
-        .build()
+fun createModelWithStructureWithoutErrorTrait(): Model {
+    return """
+        namespace smithy.example,
+        /// This is documentation about the shape.
+        structure MyStruct {
+          foo: String,
+          bar: PrimitiveInteger,
+          /// This is documentation about the member.
+          baz: Integer,
+        }
+    """.asSmithyModel()
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description of changes

Change the way we compute the nullability of members. Before we were only looking at the box trait in the target type for the `box` trait and ignoring the trait on the member itself. See for instance the test `can read box trait from member` which has the following model:

```
        namespace com.test
        structure MyStruct {
           @box
           foo: MyFoo
        }
        long MyFoo
```
The code was incorrectly assuming that the `foo` member was not nullable. This change accounts for this by using the `NullableIndex` which correctly computes whether or not the member or the target type are nullable. This change in turn was also required in several places that were making the same mistake and assuming that computing the `Symbol` for the target and testing for `isBoxed()` was enough to know if the member is itself boxed.

After this change several models from the `aws-sdk-swift` generate different code, I checked and all the changes seems legit.

**NOTE** this is a draft change as the smithy release `1.25.0` is still pending.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.