### PR TITLE
fix: add explicit conformance for Equatable and Hashable on Header, Comparable on URLQueryItem

### DIFF
--- a/Packages/ClientRuntime/Sources/Networking/Http/Headers.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/Headers.swift
@@ -162,6 +162,11 @@ public struct Headers: Hashable {
 }
 
 extension Headers: Equatable {
+    /// Returns a boolean value indicating whether two values are equal irrespective of order.
+    /// - Parameters:
+    ///   - lhs: The first `Headers` to compare.
+    ///   - rhs: The second `Headers` to compare.
+    /// - Returns: `true` if the two values are equal irrespective of order, otherwise `false`.
     public static func == (lhs: Headers, rhs: Headers) -> Bool {
         return lhs.headers.sorted() == rhs.headers.sorted()
     }
@@ -203,6 +208,11 @@ extension Header: Equatable {
 }
 
 extension Header: Comparable {
+    /// Compares two `Header` instances by name.
+    /// - Parameters:
+    ///  - lhs: The first `Header` to compare.
+    /// - rhs: The second `Header` to compare.
+    /// - Returns: `true` if the first `Header`'s name is less than the second `Header`'s name, otherwise `false`.
     public static func < (lhs: Header, rhs: Header) -> Bool {
         return lhs.name < rhs.name
     }

--- a/Packages/ClientRuntime/Sources/Networking/Http/Headers.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/Headers.swift
@@ -5,7 +5,7 @@
 
 import AwsCommonRuntimeKit
 
-public struct Headers: Equatable, Hashable {
+public struct Headers: Hashable {
     public var headers: [Header] = []
 
     /// Creates an empty instance.
@@ -161,6 +161,12 @@ public struct Headers: Equatable, Hashable {
     }
 }
 
+extension Headers: Equatable {
+    public static func == (lhs: Headers, rhs: Headers) -> Bool {
+        return lhs.headers.sorted() == rhs.headers.sorted()
+    }
+}
+
 extension Array where Element == Header {
     /// Case-insensitively finds the index of an `Header` with the provided name, if it exists.
     func index(of name: String) -> Int? {
@@ -175,7 +181,7 @@ extension Array where Element == Header {
     }
 }
 
-public struct Header: Equatable, Hashable {
+public struct Header: Hashable {
     public var name: String
     public var value: [String]
 
@@ -187,6 +193,18 @@ public struct Header: Equatable, Hashable {
     public init(name: String, value: String) {
         self.name = name
         self.value = [value]
+    }
+}
+
+extension Header: Equatable {
+    public static func == (lhs: Header, rhs: Header) -> Bool {
+        return lhs.name == rhs.name && lhs.value.sorted() == rhs.value.sorted()
+    }
+}
+
+extension Header: Comparable {
+    public static func < (lhs: Header, rhs: Header) -> Bool {
+        return lhs.name < rhs.name
     }
 }
 

--- a/Packages/ClientRuntime/Sources/PrimitiveTypeExtensions/URLQueryItem+Extensions.swift
+++ b/Packages/ClientRuntime/Sources/PrimitiveTypeExtensions/URLQueryItem+Extensions.swift
@@ -7,6 +7,11 @@ import struct Foundation.URLQueryItem
 public typealias URLQueryItem = Foundation.URLQueryItem
 
 extension URLQueryItem: Comparable {
+    /// Compares two `URLQueryItem` instances by their `name` property.
+    /// - Parameters:
+    ///  - lhs: The first `URLQueryItem` to compare.
+    /// - rhs: The second `URLQueryItem` to compare.
+    /// - Returns: `true` if the `name` property of `lhs` is less than the `name` property of `rhs`.
     public static func < (lhs: URLQueryItem, rhs: URLQueryItem) -> Bool {
         lhs.name < rhs.name
     }

--- a/Packages/ClientRuntime/Sources/PrimitiveTypeExtensions/URLQueryItem+Extensions.swift
+++ b/Packages/ClientRuntime/Sources/PrimitiveTypeExtensions/URLQueryItem+Extensions.swift
@@ -5,3 +5,9 @@
 
 import struct Foundation.URLQueryItem
 public typealias URLQueryItem = Foundation.URLQueryItem
+
+extension URLQueryItem: Comparable {
+    public static func < (lhs: URLQueryItem, rhs: URLQueryItem) -> Bool {
+        lhs.name < rhs.name
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

Change required for https://github.com/awslabs/aws-sdk-swift/pull/651


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.