### PR TITLE
chore: add appendingPathComponent string extension

### DIFF
--- a/Packages/ClientRuntime/Sources/PrimitiveTypeExtensions/String+Extensions.swift
+++ b/Packages/ClientRuntime/Sources/PrimitiveTypeExtensions/String+Extensions.swift
@@ -130,18 +130,25 @@ public extension String {
     /// - Parameter pathComponent: The path component to append to the string
     /// - Returns: The string with the path component appended
     func appendingPathComponent(_ pathComponent: String) -> String {
+        let path: String
         if self.hasSuffix("/") {
             if pathComponent.hasPrefix("/") {
-                return self + pathComponent.dropFirst()
+                path = self + pathComponent.dropFirst()
             } else {
-                return self + pathComponent
+                path = self + pathComponent
             }
         } else {
             if pathComponent.hasPrefix("/") {
-                return self + pathComponent
+                path = self + pathComponent
             } else {
-                return self + "/" + pathComponent
+                path = self + "/" + pathComponent
             }
+        }
+
+        if path.count > 1 && path.hasSuffix("/") {
+            return String(path.dropLast())
+        } else {
+            return path
         }
     }
 }

--- a/Packages/ClientRuntime/Sources/PrimitiveTypeExtensions/String+Extensions.swift
+++ b/Packages/ClientRuntime/Sources/PrimitiveTypeExtensions/String+Extensions.swift
@@ -124,3 +124,24 @@ public extension String {
         return self
     }
 }
+
+public extension String {
+    /// Returns a substring after the last occurrence of `separator` or original string if `separator` is absent
+    /// - Parameter pathComponent: The path component to append to the string
+    /// - Returns: The string with the path component appended
+    func appendingPathComponent(_ pathComponent: String) -> String {
+        if self.hasSuffix("/") {
+            if pathComponent.hasPrefix("/") {
+                return self + pathComponent.dropFirst()
+            } else {
+                return self + pathComponent
+            }
+        } else {
+            if pathComponent.hasPrefix("/") {
+                return self + pathComponent
+            } else {
+                return self + "/" + pathComponent
+            }
+        }
+    }
+}

--- a/Packages/ClientRuntime/Tests/ClientRuntimeTests/PrimitiveTypeExtensionsTests/StringExtensionsTests.swift
+++ b/Packages/ClientRuntime/Tests/ClientRuntimeTests/PrimitiveTypeExtensionsTests/StringExtensionsTests.swift
@@ -121,7 +121,7 @@ class StringExtensionsTests: XCTestCase {
     func testAppendingPathComponent_NonePresent() {
         let path = ""
         let component = ""
-        let expected = ""
+        let expected = "/"
         XCTAssertEqual(path.appendingPathComponent(component), expected)
     }
 }

--- a/Packages/ClientRuntime/Tests/ClientRuntimeTests/PrimitiveTypeExtensionsTests/StringExtensionsTests.swift
+++ b/Packages/ClientRuntime/Tests/ClientRuntimeTests/PrimitiveTypeExtensionsTests/StringExtensionsTests.swift
@@ -96,4 +96,32 @@ class StringExtensionsTests: XCTestCase {
             XCTAssertEqual(string.substringBefore(":"), match)
         }
     }
+
+    func testAppendingPathComponent_BothPresent() {
+        let path = "/foo/bar"
+        let component = "/baz"
+        let expected = "/foo/bar/baz"
+        XCTAssertEqual(path.appendingPathComponent(component), expected)
+    }
+
+    func testAppendingPathComponent_FirstComponentPresent() {
+        let path = "/foo/bar"
+        let component = ""
+        let expected = "/foo/bar"
+        XCTAssertEqual(path.appendingPathComponent(component), expected)
+    }
+    
+    func testAppendingPathComponent_SecondComponentPresent() {
+        let path = ""
+        let component = "/baz"
+        let expected = "/baz"
+        XCTAssertEqual(path.appendingPathComponent(component), expected)
+    }
+
+    func testAppendingPathComponent_NonePresent() {
+        let path = ""
+        let component = ""
+        let expected = ""
+        XCTAssertEqual(path.appendingPathComponent(component), expected)
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

Companion PR for https://github.com/awslabs/aws-sdk-swift/pull/660

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.