### PR TITLE
fix: Provide an encoding customization that allows empty lists to be serialized

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/formurl/FormURLEncodeCustomizable.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/formurl/FormURLEncodeCustomizable.kt
@@ -10,4 +10,5 @@ import software.amazon.smithy.model.shapes.Shape
 interface FormURLEncodeCustomizable {
     fun alwaysUsesFlattenedCollections(): Boolean
     fun customNameTraitGenerator(memberShape: Shape, defaultName: String): String
+    fun shouldSerializeEmptyLists(): Boolean
 }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/formurl/MemberShapeEncodeFormURLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/formurl/MemberShapeEncodeFormURLGenerator.kt
@@ -40,20 +40,19 @@ abstract class MemberShapeEncodeFormURLGenerator(
         val resolvedMemberName = customizations.customNameTraitGenerator(member, member.memberName)
         val nestedContainer = "${memberName}Container"
         writer.openBlock("if let $memberName = $memberName {", "}") {
-            if (member.hasTrait(XmlFlattenedTrait::class.java) || customizations.alwaysUsesFlattenedCollections()) {
-                writer.openBlock("if !$memberName.isEmpty {", "}") {
+            writer.openBlock("if !$memberName.isEmpty {", "}") {
+                if (member.hasTrait(XmlFlattenedTrait::class.java) || customizations.alwaysUsesFlattenedCollections()) {
                     renderFlattenedListMemberItems(memberName, member, memberTarget, containerName)
+                } else {
+                    writer.write("var $nestedContainer = $containerName.nestedContainer(keyedBy: \$N.self, forKey: \$N(\"$resolvedMemberName\"))", ClientRuntimeTypes.Serde.Key, ClientRuntimeTypes.Serde.Key)
+                    renderListMemberItems(memberName, memberTarget, nestedContainer)
                 }
-                if (customizations.shouldSerializeEmptyLists()) {
-                    val resolvedMemberName = customizations.customNameTraitGenerator(member, memberName)
-                    writer.openBlock("else {", "}") {
-                        writer.write("var $nestedContainer = $containerName.nestedContainer(keyedBy: \$N.self, forKey: \$N(\"$resolvedMemberName\"))", ClientRuntimeTypes.Serde.Key, ClientRuntimeTypes.Serde.Key)
-                        writer.write("try $nestedContainer.encode(\"\", forKey: \$N(\"\"))", ClientRuntimeTypes.Serde.Key)
-                    }
+            }
+            if (customizations.shouldSerializeEmptyLists()) {
+                writer.openBlock("else {", "}") {
+                    writer.write("var $nestedContainer = $containerName.nestedContainer(keyedBy: \$N.self, forKey: \$N(\"$resolvedMemberName\"))", ClientRuntimeTypes.Serde.Key, ClientRuntimeTypes.Serde.Key)
+                    writer.write("try $nestedContainer.encode(\"\", forKey: \$N(\"\"))", ClientRuntimeTypes.Serde.Key)
                 }
-            } else {
-                writer.write("var $nestedContainer = $containerName.nestedContainer(keyedBy: \$N.self, forKey: \$N(\"$resolvedMemberName\"))", ClientRuntimeTypes.Serde.Key, ClientRuntimeTypes.Serde.Key)
-                renderListMemberItems(memberName, memberTarget, nestedContainer)
             }
         }
     }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/formurl/MemberShapeEncodeFormURLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/formurl/MemberShapeEncodeFormURLGenerator.kt
@@ -44,6 +44,13 @@ abstract class MemberShapeEncodeFormURLGenerator(
                 writer.openBlock("if !$memberName.isEmpty {", "}") {
                     renderFlattenedListMemberItems(memberName, member, memberTarget, containerName)
                 }
+                if (customizations.shouldSerializeEmptyLists()) {
+                    val resolvedMemberName = customizations.customNameTraitGenerator(member, memberName)
+                    writer.openBlock("else {", "}") {
+                        writer.write("var $nestedContainer = $containerName.nestedContainer(keyedBy: \$N.self, forKey: \$N(\"$resolvedMemberName\"))", ClientRuntimeTypes.Serde.Key, ClientRuntimeTypes.Serde.Key)
+                        writer.write("try $nestedContainer.encode(\"\", forKey: \$N(\"\"))", ClientRuntimeTypes.Serde.Key)
+                    }
+                }
             } else {
                 writer.write("var $nestedContainer = $containerName.nestedContainer(keyedBy: \$N.self, forKey: \$N(\"$resolvedMemberName\"))", ClientRuntimeTypes.Serde.Key, ClientRuntimeTypes.Serde.Key)
                 renderListMemberItems(memberName, memberTarget, nestedContainer)

--- a/smithy-swift-codegen/src/test/kotlin/mocks/MockHttpEC2QueryProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/mocks/MockHttpEC2QueryProtocolGenerator.kt
@@ -60,6 +60,10 @@ class MockEc2QueryFormURLEncodeCustomizations : FormURLEncodeCustomizable {
     override fun customNameTraitGenerator(shape: Shape, defaultName: String): String {
         return Ec2QueryNameTraitGenerator.construct(shape, defaultName).toString()
     }
+
+    override fun shouldSerializeEmptyLists(): Boolean {
+        return true
+    }
 }
 
 class MockHttpEC2QueryProtocolGenerator : HttpBindingProtocolGenerator() {

--- a/smithy-swift-codegen/src/test/kotlin/serde/ec2/OnlyFlattenedListEncodeFormURLGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/ec2/OnlyFlattenedListEncodeFormURLGeneratorTests.kt
@@ -32,6 +32,10 @@ class OnlyFlattenedListEncodeFormURLGeneratorTests {
                                 try complexListArgContainer0.encode(greetingstruct0, forKey: ClientRuntime.Key(""))
                             }
                         }
+                        else {
+                            var complexListArgContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ComplexListArg"))
+                            try complexListArgContainer.encode("", forKey: ClientRuntime.Key(""))
+                        }
                     }
                     if let listArg = listArg {
                         if !listArg.isEmpty {
@@ -39,6 +43,10 @@ class OnlyFlattenedListEncodeFormURLGeneratorTests {
                                 var listArgContainer0 = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ListArg.\(index0.advanced(by: 1))"))
                                 try listArgContainer0.encode(string0, forKey: ClientRuntime.Key(""))
                             }
+                        }
+                        else {
+                            var listArgContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ListArg"))
+                            try listArgContainer.encode("", forKey: ClientRuntime.Key(""))
                         }
                     }
                     if let listArgWithXmlName = listArgWithXmlName {
@@ -48,6 +56,10 @@ class OnlyFlattenedListEncodeFormURLGeneratorTests {
                                 try listArgWithXmlNameContainer0.encode(string0, forKey: ClientRuntime.Key(""))
                             }
                         }
+                        else {
+                            var listArgWithXmlNameContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("Hi"))
+                            try listArgWithXmlNameContainer.encode("", forKey: ClientRuntime.Key(""))
+                        }
                     }
                     if let listArgWithXmlNameMember = listArgWithXmlNameMember {
                         if !listArgWithXmlNameMember.isEmpty {
@@ -55,6 +67,10 @@ class OnlyFlattenedListEncodeFormURLGeneratorTests {
                                 var listArgWithXmlNameMemberContainer0 = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ListArgWithXmlNameMember.\(index0.advanced(by: 1))"))
                                 try listArgWithXmlNameMemberContainer0.encode(string0, forKey: ClientRuntime.Key(""))
                             }
+                        }
+                        else {
+                            var listArgWithXmlNameMemberContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ListArgWithXmlNameMember"))
+                            try listArgWithXmlNameMemberContainer.encode("", forKey: ClientRuntime.Key(""))
                         }
                     }
                     try container.encode("Ec2QueryLists", forKey:ClientRuntime.Key("Action"))


### PR DESCRIPTION
This PR provides a form url encoding customization option that allows for empty lists to be serialized.
Previously, empty lists would never be serialized.

## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/665


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.