### PR TITLE
feat: add support for wss request signing

### DIFF
--- a/Packages/ClientRuntime/Sources/Networking/Http/ProtocolType.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/ProtocolType.swift
@@ -8,4 +8,5 @@ import Foundation
 public enum ProtocolType: String, CaseIterable {
     case http
     case https
+    case wss
 }

--- a/Packages/ClientRuntime/Tests/ClientRuntimeTests/NetworkingTests/SdkRequestBuilderTests.swift
+++ b/Packages/ClientRuntime/Tests/ClientRuntimeTests/NetworkingTests/SdkRequestBuilderTests.swift
@@ -21,4 +21,21 @@ class SdkRequestBuilderTests: XCTestCase {
         XCTAssertEqual(pathToMatch, updatedPath)
         XCTAssertEqual(url, updatedRequest.endpoint.url?.absoluteString)
     }
+
+    func testBuildWSSRequest() {
+        let protocolType = ProtocolType.wss
+        let host = "foo.us-east-1.amazonaws.com"
+        let path = "/hello-world"
+        let queryItem = (name: "bar", value: "baz")
+        let request = SdkHttpRequestBuilder()
+            .withProtocol(protocolType)
+            .withHost(host)
+            .withPath(path)
+            .withQueryItem(.init(name: queryItem.name, value: queryItem.value))
+            .build()
+
+        let expectedOutput = "\(protocolType.rawValue)://\(host)\(path)?\(queryItem.name)=\(queryItem.value)"
+
+        XCTAssertEqual(request.endpoint.url?.absoluteString, expectedOutput)
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Adds a `wss` case to the `ProtocolType` enum to support `wss` request signing + simple unit test.
Confirmed this works by manual testing through `AWSClientRuntime.AWSSigV4Signer.sigV4SignedRequest(requestBuilder:signingConfig:)`.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.