### PR TITLE
Exposes model property in CodegenVisitor

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/CodegenVisitor.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/CodegenVisitor.kt
@@ -35,7 +35,7 @@ class CodegenVisitor(context: PluginContext) : ShapeVisitor.Default<Void>() {
 
     private val LOGGER = Logger.getLogger(javaClass.name)
     private val settings: SwiftSettings = SwiftSettings.from(context.model, context.settings)
-    private val model: Model
+    val model: Model
     private val service: ServiceShape
     private val fileManifest: FileManifest = context.fileManifest
     private val symbolProvider: SymbolProvider


### PR DESCRIPTION
https://github.com/awslabs/aws-sdk-swift/pull/709

## Description of changes
This PR exposes the `model` property in `CodegenVisitor` to make the codegen behavior in tests more consistent with that in release.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.