### PR TITLE
fix: Properly encode empty bodies for json and xml

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/handlers/HttpBodyMiddleware.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/handlers/HttpBodyMiddleware.kt
@@ -102,23 +102,7 @@ class HttpBodyMiddleware(
                     renderEncodedBodyAddedToRequest(bodyDeclaration, dataDeclaration)
                 }
             }
-            ShapeType.STRUCTURE, ShapeType.UNION -> {
-                // delegate to the member encode function
-                writer.openBlock("do {", "} catch let err {") {
-                    writer.write("let encoder = context.getEncoder()")
-                    writer.openBlock("if let $memberName = input.operationInput.$memberName {", "} else {") {
-                        writer.write("let $dataDeclaration = try encoder.encode(\$L)", memberName)
-                        renderEncodedBodyAddedToRequest(bodyDeclaration, dataDeclaration)
-                    }
-                    writer.indent()
-                    writer.write("let $dataDeclaration = try encoder.encode(input.operationInput)")
-                    renderEncodedBodyAddedToRequest(bodyDeclaration, dataDeclaration)
-                    writer.dedent()
-                    writer.write("}")
-                }
-                renderErrorCase()
-            }
-            ShapeType.DOCUMENT -> {
+            ShapeType.DOCUMENT, ShapeType.STRUCTURE, ShapeType.UNION -> {
                 writer.openBlock("do {", "} catch let err {") {
                     writer.openBlock("if let $memberName = input.operationInput.$memberName {", "}") {
                         writer.write("let encoder = context.getEncoder()")

--- a/smithy-swift-codegen/src/test/kotlin/HttpBodyMiddlewareTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpBodyMiddlewareTests.kt
@@ -149,11 +149,23 @@ class HttpBodyMiddlewareTests {
                 Self.Context == H.Context
                 {
                     do {
+                        let encoder = context.getEncoder()
                         if let payload1 = input.operationInput.payload1 {
-                            let encoder = context.getEncoder()
                             let payload1data = try encoder.encode(payload1)
                             let payload1body = ClientRuntime.HttpBody.data(payload1data)
                             input.builder.withBody(payload1body)
+                        } else {
+                            if encoder is JSONEncoder {
+                                // Encode an empty body as an empty structure in JSON
+                                let payload1data = "{}".data(using: .utf8)!
+                                let payload1body = ClientRuntime.HttpBody.data(payload1data)
+                                input.builder.withBody(payload1body)
+                            } else if encoder is XMLEncoder {
+                                // Encode an empty body as an empty string in XML
+                                let payload1data = "".data(using: .utf8)!
+                                let payload1body = ClientRuntime.HttpBody.data(payload1data)
+                                input.builder.withBody(payload1body)
+                            }
                         }
                     } catch let err {
                         throw SdkError<ExplicitStructOutputError>.client(ClientRuntime.ClientError.serializationFailed(err.localizedDescription))

--- a/smithy-swift-codegen/src/test/kotlin/HttpBodyMiddlewareTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpBodyMiddlewareTests.kt
@@ -149,13 +149,9 @@ class HttpBodyMiddlewareTests {
                 Self.Context == H.Context
                 {
                     do {
-                        let encoder = context.getEncoder()
                         if let payload1 = input.operationInput.payload1 {
+                            let encoder = context.getEncoder()
                             let payload1data = try encoder.encode(payload1)
-                            let payload1body = ClientRuntime.HttpBody.data(payload1data)
-                            input.builder.withBody(payload1body)
-                        } else {
-                            let payload1data = try encoder.encode(input.operationInput)
                             let payload1body = ClientRuntime.HttpBody.data(payload1data)
                             input.builder.withBody(payload1body)
                         }


### PR DESCRIPTION
This PR properly encodes empty bodies. 
For JSON -> encode as "{}"
for XML -> encode as ""

## Issue \#
[<!--- If it fixes an open issue, please link to the issue here -->](https://github.com/awslabs/aws-sdk-swift/issues/580)


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.