### PR TITLE
No-ops instead of encoding empty string when encoding an empty body in xml

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/handlers/HttpBodyMiddleware.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/handlers/HttpBodyMiddleware.kt
@@ -111,17 +111,11 @@ class HttpBodyMiddleware(
                         renderEncodedBodyAddedToRequest(bodyDeclaration, dataDeclaration)
                     }
                     writer.indent()
-                    writer.openBlock("if encoder is JSONEncoder {", "} else if encoder is XMLEncoder {") {
+                    writer.openBlock("if encoder is JSONEncoder {", "}") {
                         writer.write("// Encode an empty body as an empty structure in JSON")
                         writer.write("let \$L = \"{}\".data(using: .utf8)!", dataDeclaration)
                         renderEncodedBodyAddedToRequest(bodyDeclaration, dataDeclaration)
                     }
-                    writer.indent()
-                    writer.write("// Encode an empty body as an empty string in XML")
-                    writer.write("let \$L = \"\".data(using: .utf8)!", dataDeclaration)
-                    renderEncodedBodyAddedToRequest(bodyDeclaration, dataDeclaration)
-                    writer.dedent()
-                    writer.write("}")
                     writer.dedent()
                     writer.write("}")
                 }

--- a/smithy-swift-codegen/src/test/kotlin/HttpBodyMiddlewareTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpBodyMiddlewareTests.kt
@@ -149,8 +149,8 @@ class HttpBodyMiddlewareTests {
                 Self.Context == H.Context
                 {
                     do {
-                        let encoder = context.getEncoder()
                         if let payload1 = input.operationInput.payload1 {
+                            let encoder = context.getEncoder()
                             let payload1data = try encoder.encode(payload1)
                             let payload1body = ClientRuntime.HttpBody.data(payload1data)
                             input.builder.withBody(payload1body)

--- a/smithy-swift-codegen/src/test/kotlin/HttpBodyMiddlewareTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpBodyMiddlewareTests.kt
@@ -149,8 +149,8 @@ class HttpBodyMiddlewareTests {
                 Self.Context == H.Context
                 {
                     do {
+                        let encoder = context.getEncoder()
                         if let payload1 = input.operationInput.payload1 {
-                            let encoder = context.getEncoder()
                             let payload1data = try encoder.encode(payload1)
                             let payload1body = ClientRuntime.HttpBody.data(payload1data)
                             input.builder.withBody(payload1body)

--- a/smithy-swift-codegen/src/test/kotlin/HttpBodyMiddlewareTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpBodyMiddlewareTests.kt
@@ -160,11 +160,6 @@ class HttpBodyMiddlewareTests {
                                 let payload1data = "{}".data(using: .utf8)!
                                 let payload1body = ClientRuntime.HttpBody.data(payload1data)
                                 input.builder.withBody(payload1body)
-                            } else if encoder is XMLEncoder {
-                                // Encode an empty body as an empty string in XML
-                                let payload1data = "".data(using: .utf8)!
-                                let payload1body = ClientRuntime.HttpBody.data(payload1data)
-                                input.builder.withBody(payload1body)
                             }
                         }
                     } catch let err {


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/580

## Description of changes
This PR removes the logic that encodes an empty string for an empty body in xml. 
Encoding an empty string, results in a "invalid list" error in CRT. (unknown if that is expected or not)

Regardless, doing nothing (or encoding nil) is preferable and more accurate as the expected payload should be empty.


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.