### PR TITLE
Fix log level parameter being ignored

### DIFF
--- a/Packages/ClientRuntime/Sources/Logging/SwiftLog+LogAgent.swift
+++ b/Packages/ClientRuntime/Sources/Logging/SwiftLog+LogAgent.swift
@@ -39,7 +39,7 @@ public struct SwiftLogger: LogAgent {
         let mappedDict = metadata?.mapValues { (value) -> Logger.MetadataValue in
             return Logger.MetadataValue.string(value)
         }
-        self.logger.log(level: logLevel.toLoggerLevel(),
+        self.logger.log(level: level.toLoggerLevel(),
                         Logger.Message(stringLiteral: message),
                         metadata: mappedDict,
                         source: source,


### PR DESCRIPTION
The `level` argument to [this function](https://github.com/awslabs/smithy-swift/blob/ae509e0025ff425df3bf0847413574d0a151d8c0/Packages/ClientRuntime/Sources/Logging/SwiftLog%2BLogAgent.swift#L32-L50) is currently ignored. Instead, the function calls the `logLevel` property on the `SwiftLogger` struct. This means that no matter whether a log is created via any level, whether it's `.debug()` or `.fatal()`, the logs that are generated are always created at whatever level the `SwiftLogger` has in its stored property, which is usually `.info`. I'm pretty sure this is a typo, and it causes any command-line tools that are made using this SDK to output so much debug information that it obscures the intended program output.

## Issue \#
https://github.com/awslabs/smithy-swift/issues/486

## Description of changes
It fixes a typo, so that the `level` parameter is actually used, and logs get logged at the level the caller intended to log them at.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.