### PR TITLE
Fixes XML encoding issues

### DIFF
--- a/Packages/SmithyTestUtil/Sources/JSONComparator.swift
+++ b/Packages/SmithyTestUtil/Sources/JSONComparator.swift
@@ -1,0 +1,53 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public struct JSONComparator {
+    /// Returns true if the JSON documents, for the corresponding data objects, are equal.
+    /// - Parameters:
+    ///   - dataA: The first data object to compare to the second data object.
+    ///   - dataB: The second data object to compare to the first data object.
+    /// - Returns: Returns true if the JSON documents, for the corresponding data objects, are equal.
+    public static func jsonData(_ dataA: Data, isEqualTo dataB: Data) throws -> Bool {
+        let jsonDictA = try JSONSerialization.jsonObject(with: dataA)
+        let jsonDictB = try JSONSerialization.jsonObject(with: dataB)
+        return anyValuesAreEqual(jsonDictA, jsonDictB)
+    }
+}
+
+fileprivate func anyDictsAreEqual(_ lhs: [String: Any], _ rhs: [String: Any]) -> Bool {
+    guard lhs.keys == rhs.keys else { return false }
+    for key in lhs.keys {
+        if !anyValuesAreEqual(lhs[key], rhs[key]) {
+            return false
+        }
+    }
+    return true
+}
+
+fileprivate func anyArraysAreEqual(_ lhs: [Any], _ rhs: [Any]) -> Bool {
+    guard lhs.count == rhs.count else { return false }
+    for i in 0..<lhs.count {
+        if !anyValuesAreEqual(lhs[i], rhs[i]) {
+            return false
+        }
+    }
+    return true
+}
+
+fileprivate func anyValuesAreEqual(_ lhs: Any?, _ rhs: Any?) -> Bool {
+    if lhs == nil && rhs == nil { return true }
+    guard let lhs = lhs, let rhs = rhs else { return false }
+    if let lhsDict = lhs as? [String: Any], let rhsDict = rhs as? [String: Any] {
+        return anyDictsAreEqual(lhsDict, rhsDict)
+    } else if let lhsArray = lhs as? [Any], let rhsArray = rhs as? [Any] {
+        return anyArraysAreEqual(lhsArray, rhsArray)
+    } else {
+        return type(of: lhs) == type(of: rhs) && "\(lhs)" == "\(rhs)"
+    }
+}

--- a/Packages/SmithyTestUtil/Sources/RequestTestUtil/HttpRequestTestBase.swift
+++ b/Packages/SmithyTestUtil/Sources/RequestTestUtil/HttpRequestTestBase.swift
@@ -231,6 +231,7 @@ open class HttpRequestTestBase: XCTestCase {
     public func genericAssertEqualHttpBodyData(
         _ expected: HttpBody,
         _ actual: HttpBody,
+        _ encoder: Any,
         _ callback: (Data, Data) -> Void,
         file: StaticString = #filePath,
         line: UInt = #line
@@ -244,6 +245,11 @@ open class HttpRequestTestBase: XCTestCase {
             return
         }
         if shouldCompareData(expectedData, actualData) {
+            if encoder is XMLEncoder {
+                XCTAssertXMLDataEqual(actualData!, expectedData!, file: file, line: line)
+            } else if encoder is JSONEncoder {
+                XCTAssertJSONDataEqual(actualData!, expectedData!, file: file, line: line)
+            }
             callback(expectedData!, actualData!)
         }
     }

--- a/Packages/SmithyTestUtil/Sources/XCTAssertions.swift
+++ b/Packages/SmithyTestUtil/Sources/XCTAssertions.swift
@@ -19,9 +19,9 @@ public func XCTAssertJSONDataEqual(
         let data1 = try expression1()
         let data2 = try expression2()
         guard data1 != data2 else { return }
-        let jsonDict1 = try JSONSerialization.jsonObject(with: data1) as! NSDictionary
-        let jsonDict2 = try JSONSerialization.jsonObject(with: data2) as! NSDictionary
-        XCTAssertTrue(jsonDict1.isEqual(to: jsonDict2), message(), file: file, line: line)
+        let jsonDict1 = try JSONSerialization.jsonObject(with: data1)
+        let jsonDict2 = try JSONSerialization.jsonObject(with: data2)
+        XCTAssertTrue(anyValuesAreEqual(jsonDict1, jsonDict2), message(), file: file, line: line)
     } catch {
         XCTFail("Failed to evaluate JSON with error: \(error)", file: file, line: line)
     }
@@ -43,3 +43,37 @@ public func XCTAssertXMLDataEqual(
         XCTFail("Failed to evaluate XML with error: \(error)", file: file, line: line)
     }
 }
+
+fileprivate func anyDictsAreEqual(_ lhs: [String: Any], _ rhs: [String: Any]) -> Bool {
+    guard lhs.keys == rhs.keys else { return false }
+    for key in lhs.keys {
+        if !anyValuesAreEqual(lhs[key], rhs[key]) {
+            return false
+        }
+    }
+    return true
+}
+
+fileprivate func anyArraysAreEqual(_ lhs: [Any], _ rhs: [Any]) -> Bool {
+    guard lhs.count == rhs.count else { return false }
+    for i in 0..<lhs.count {
+        if !anyValuesAreEqual(lhs[i], rhs[i]) {
+            return false
+        }
+    }
+    return true
+}
+
+fileprivate func anyValuesAreEqual(_ lhs: Any?, _ rhs: Any?) -> Bool {
+    if lhs == nil && rhs == nil { return true }
+    guard let lhs = lhs, let rhs = rhs else { return false }
+    if let lhsDict = lhs as? [String: Any], let rhsDict = rhs as? [String: Any] {
+        return anyDictsAreEqual(lhsDict, rhsDict)
+    } else if let lhsArray = lhs as? [Any], let rhsArray = rhs as? [Any] {
+        return anyArraysAreEqual(lhsArray, rhsArray)
+    } else {
+        return type(of: lhs) == type(of: rhs) && "\(lhs)" == "\(rhs)"
+    }
+}
+
+

--- a/Packages/SmithyTestUtil/Sources/XCTAssertions.swift
+++ b/Packages/SmithyTestUtil/Sources/XCTAssertions.swift
@@ -1,0 +1,45 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+
+public func XCTAssertJSONDataEqual(
+    _ expression1: @autoclosure () throws -> Data,
+    _ expression2: @autoclosure () throws -> Data,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    do {
+        let data1 = try expression1()
+        let data2 = try expression2()
+        guard data1 != data2 else { return }
+        let jsonDict1 = try JSONSerialization.jsonObject(with: data1) as! NSDictionary
+        let jsonDict2 = try JSONSerialization.jsonObject(with: data2) as! NSDictionary
+        XCTAssertTrue(jsonDict1.isEqual(to: jsonDict2), message(), file: file, line: line)
+    } catch {
+        XCTFail("Failed to evaluate JSON with error: \(error)", file: file, line: line)
+    }
+}
+
+public func XCTAssertXMLDataEqual(
+    _ expression1: @autoclosure () throws -> Data,
+    _ expression2: @autoclosure () throws -> Data,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    do {
+        let data1 = try expression1()
+        let data2 = try expression2()
+        guard data1 != data2 else { return }
+        XCTAssertTrue(XMLComparator.xmlData(data1, isEqualTo: data2), message(), file: file, line: line)
+    } catch {
+        XCTFail("Failed to evaluate XML with error: \(error)", file: file, line: line)
+    }
+}

--- a/Packages/SmithyTestUtil/Sources/XCTAssertions.swift
+++ b/Packages/SmithyTestUtil/Sources/XCTAssertions.swift
@@ -19,9 +19,12 @@ public func XCTAssertJSONDataEqual(
         let data1 = try expression1()
         let data2 = try expression2()
         guard data1 != data2 else { return }
-        let jsonDict1 = try JSONSerialization.jsonObject(with: data1)
-        let jsonDict2 = try JSONSerialization.jsonObject(with: data2)
-        XCTAssertTrue(anyValuesAreEqual(jsonDict1, jsonDict2), message(), file: file, line: line)
+        XCTAssertTrue(
+            try JSONComparator.jsonData(data1, isEqualTo: data2),
+            message(),
+            file: file,
+            line: line
+        )
     } catch {
         XCTFail("Failed to evaluate JSON with error: \(error)", file: file, line: line)
     }
@@ -43,37 +46,3 @@ public func XCTAssertXMLDataEqual(
         XCTFail("Failed to evaluate XML with error: \(error)", file: file, line: line)
     }
 }
-
-fileprivate func anyDictsAreEqual(_ lhs: [String: Any], _ rhs: [String: Any]) -> Bool {
-    guard lhs.keys == rhs.keys else { return false }
-    for key in lhs.keys {
-        if !anyValuesAreEqual(lhs[key], rhs[key]) {
-            return false
-        }
-    }
-    return true
-}
-
-fileprivate func anyArraysAreEqual(_ lhs: [Any], _ rhs: [Any]) -> Bool {
-    guard lhs.count == rhs.count else { return false }
-    for i in 0..<lhs.count {
-        if !anyValuesAreEqual(lhs[i], rhs[i]) {
-            return false
-        }
-    }
-    return true
-}
-
-fileprivate func anyValuesAreEqual(_ lhs: Any?, _ rhs: Any?) -> Bool {
-    if lhs == nil && rhs == nil { return true }
-    guard let lhs = lhs, let rhs = rhs else { return false }
-    if let lhsDict = lhs as? [String: Any], let rhsDict = rhs as? [String: Any] {
-        return anyDictsAreEqual(lhsDict, rhsDict)
-    } else if let lhsArray = lhs as? [Any], let rhsArray = rhs as? [Any] {
-        return anyArraysAreEqual(lhsArray, rhsArray)
-    } else {
-        return type(of: lhs) == type(of: rhs) && "\(lhs)" == "\(rhs)"
-    }
-}
-
-

--- a/Packages/SmithyTestUtil/Sources/XMLComparator.swift
+++ b/Packages/SmithyTestUtil/Sources/XMLComparator.swift
@@ -1,0 +1,82 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public struct XMLComparator {
+    public static func xmlData(_ dataA: Data, isEqualTo dataB: Data) -> Bool {
+        let rootA = XMLConverter.xmlTree(with: dataA)
+        let rootB = XMLConverter.xmlTree(with: dataB)
+        return rootA == rootB
+    }
+}
+
+private struct XMLElement: Hashable {
+    var name: String?
+    var attributes: [String : String]?
+    var string: String?
+    var elements: Set<XMLElement> = []
+}
+
+private class XMLConverter: NSObject {
+    /// Keeps track of the value since `foundCharacters` can be called multiple times for the same element
+    private var valueBuffer = ""
+    private var stack: [XMLElement] = []
+        
+    static func xmlTree(with data: Data) -> XMLElement {
+        let converter = XMLConverter()
+        converter.stack.append(XMLElement())
+        
+        let parser = XMLParser(data: data)
+        parser.delegate = converter
+        parser.parse()
+        
+        return converter.stack.first!
+    }
+}
+
+extension XMLConverter: XMLParserDelegate {
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String : String] = [:]
+    ) {
+        let parent = stack.last!
+        let element = XMLElement(
+            name: elementName,
+            attributes: attributeDict
+        )
+        
+        stack.append(element)
+    }
+    
+    func parser(_ parser: XMLParser, foundCharacters string: String) {
+        let trimmedString = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        valueBuffer.append(trimmedString)
+    }
+    
+    func parser(
+        _ parser: XMLParser, didEndElement
+        elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        var element = stack.popLast()!
+        var parent = stack.last!
+        
+        element.string = valueBuffer
+        
+        var elements = parent.elements
+        elements.insert(element)
+        parent.elements = elements
+        
+        stack[stack.endIndex - 1] = parent
+        valueBuffer = ""
+    }
+}

--- a/Packages/SmithyTestUtil/Sources/XMLComparator.swift
+++ b/Packages/SmithyTestUtil/Sources/XMLComparator.swift
@@ -15,6 +15,12 @@ import FoundationXML
 #endif
 
 public struct XMLComparator {
+    /// Returns true if the XML documents, for the corresponding data objects, are equal.
+    /// Order of elements within the document do not affect equality.
+    /// - Parameters:
+    ///   - dataA: The first data object to compare to the second data object.
+    ///   - dataB: The second data object to compare to the first data object.
+    /// - Returns: Returns true if the XML documents, for the corresponding data objects, are equal.
     public static func xmlData(_ dataA: Data, isEqualTo dataB: Data) -> Bool {
         let rootA = XMLConverter.xmlTree(with: dataA)
         let rootB = XMLConverter.xmlTree(with: dataB)

--- a/Packages/SmithyTestUtil/Sources/XMLComparator.swift
+++ b/Packages/SmithyTestUtil/Sources/XMLComparator.swift
@@ -6,6 +6,13 @@
 //
 
 import Foundation
+#if canImport(FoundationXML)
+// As of Swift 5.1, the Foundation module on Linux only has the same set of dependencies as the Swift standard library itself
+// Therefore, we need to explicitly import FoundationXML on linux.
+// The preferred way to do this, is to check if FoundationXML can be imported.
+// https://github.com/apple/swift-corelibs-foundation/blob/main/Docs/ReleaseNotes_Swift5.md
+import FoundationXML
+#endif
 
 public struct XMLComparator {
     public static func xmlData(_ dataA: Data, isEqualTo dataB: Data) -> Bool {

--- a/Packages/SmithyTestUtil/Tests/RequestTestUtilTests/HttpRequestTestBaseTests.swift
+++ b/Packages/SmithyTestUtil/Tests/RequestTestUtilTests/HttpRequestTestBaseTests.swift
@@ -214,7 +214,7 @@ class HttpRequestTestBaseTests: HttpRequestTestBase {
             self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
                 XCTAssertNotNil(expectedHttpBody, "The expected HttpBody is nil")
-                self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!) { (expectedData, actualData) in
+                self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!, JSONEncoder()) { (expectedData, actualData) in
                     do {
                          let decoder = JSONDecoder()
                          let expectedObj = try decoder.decode(SayHelloInputBody.self, from: expectedData)

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
@@ -147,7 +147,7 @@ open class HttpProtocolUnitTestRequestGenerator protected constructor(builder: B
                 writer.write("XCTAssertNotNil(expectedHttpBody, \"The expected HttpBody is nil\")")
                 val expectedData = "expectedData"
                 val actualData = "actualData"
-                writer.openBlock("self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!) { $expectedData, $actualData in ", "}") {
+                writer.openBlock("self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!, encoder) { $expectedData, $actualData in ", "}") {
                     val httpPayloadShape = inputShape.members().firstOrNull { it.hasTrait(HttpPayloadTrait::class.java) }
 
                     httpPayloadShape?.let {
@@ -202,6 +202,11 @@ open class HttpProtocolUnitTestRequestGenerator protected constructor(builder: B
         writer.write("XCTFail(\"Failed to verify body \\(err)\")")
         writer.dedent()
         writer.write("}")
+    }
+
+    private fun renderDataComparison(writer: SwiftWriter, expectedData: String, actualData: String) {
+        val assertionMethod = "XCTAssertJSONDataEqual"
+        writer.write("\$L(\$L, \$L, \"Some error message\")", assertionMethod, actualData, expectedData)
     }
 
     protected open fun renderAssertions(test: HttpRequestTestCase, outputShape: Shape) {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/handlers/HttpBodyMiddleware.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/handlers/HttpBodyMiddleware.kt
@@ -24,7 +24,6 @@ import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.steps.OperationSerializeStep
 import software.amazon.smithy.swift.codegen.model.getTrait
 import software.amazon.smithy.swift.codegen.model.hasTrait
-import software.amazon.smithy.swift.codegen.model.targetOrSelf
 
 class HttpBodyMiddleware(
     private val writer: SwiftWriter,
@@ -111,7 +110,7 @@ class HttpBodyMiddleware(
                     writer.write("let encoder = context.getEncoder()")
                     writer.openBlock("if let $memberName = input.operationInput.$memberName {", "} else {") {
 
-                        val xmlNameTrait = binding.member.getTrait<XmlNameTrait>() ?:  target.getTrait<XmlNameTrait>()
+                        val xmlNameTrait = binding.member.getTrait<XmlNameTrait>() ?: target.getTrait<XmlNameTrait>()
                         if (xmlNameTrait != null) {
                             val xmlName = xmlNameTrait.value
                             writer.write("let xmlEncoder = encoder as! XMLEncoder")

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/handlers/HttpBodyMiddleware.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/handlers/HttpBodyMiddleware.kt
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.swift.codegen.integration.middlewares.handlers
 
+import software.amazon.smithy.aws.traits.protocols.RestXmlTrait
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.knowledge.HttpBinding
@@ -111,7 +112,7 @@ class HttpBodyMiddleware(
                     writer.openBlock("if let $memberName = input.operationInput.$memberName {", "} else {") {
 
                         val xmlNameTrait = binding.member.getTrait<XmlNameTrait>() ?: target.getTrait<XmlNameTrait>()
-                        if (xmlNameTrait != null) {
+                        if (ctx.protocol == RestXmlTrait.ID && xmlNameTrait != null) {
                             val xmlName = xmlNameTrait.value
                             writer.write("let xmlEncoder = encoder as! XMLEncoder")
                             writer.write(

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/handlers/HttpBodyMiddleware.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/handlers/HttpBodyMiddleware.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ShapeType
 import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.StreamingTrait
+import software.amazon.smithy.model.traits.XmlNameTrait
 import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
 import software.amazon.smithy.swift.codegen.Middleware
 import software.amazon.smithy.swift.codegen.MiddlewareGenerator
@@ -21,7 +22,9 @@ import software.amazon.smithy.swift.codegen.integration.HttpBindingDescriptor
 import software.amazon.smithy.swift.codegen.integration.HttpBindingResolver
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.steps.OperationSerializeStep
+import software.amazon.smithy.swift.codegen.model.getTrait
 import software.amazon.smithy.swift.codegen.model.hasTrait
+import software.amazon.smithy.swift.codegen.model.targetOrSelf
 
 class HttpBodyMiddleware(
     private val writer: SwiftWriter,
@@ -107,7 +110,19 @@ class HttpBodyMiddleware(
                 writer.openBlock("do {", "} catch let err {") {
                     writer.write("let encoder = context.getEncoder()")
                     writer.openBlock("if let $memberName = input.operationInput.$memberName {", "} else {") {
-                        writer.write("let $dataDeclaration = try encoder.encode(\$L)", memberName)
+
+                        val xmlNameTrait = binding.member.getTrait<XmlNameTrait>() ?:  target.getTrait<XmlNameTrait>()
+                        if (xmlNameTrait != null) {
+                            val xmlName = xmlNameTrait.value
+                            writer.write("let xmlEncoder = encoder as! XMLEncoder")
+                            writer.write(
+                                "let $dataDeclaration = try xmlEncoder.encode(\$L, withRootKey: \"\$L\")",
+                                memberName, xmlName
+                            )
+                        } else {
+                            writer.write("let $dataDeclaration = try encoder.encode(\$L)", memberName)
+                        }
+
                         renderEncodedBodyAddedToRequest(bodyDeclaration, dataDeclaration)
                     }
                     writer.indent()

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeEncodeXMLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeEncodeXMLGenerator.kt
@@ -373,17 +373,13 @@ abstract class MemberShapeEncodeXMLGenerator(
     }
 
     private fun renderItem(writer: SwiftWriter, XMLNamespaceTraitGenerator: XMLNamespaceTraitGenerator?, nestedContainerName: String, containerName: String, memberName: String, memberTarget: Shape, resolvedMemberName: String) {
-        var renderableMemberName = memberName
-        if (MemberShapeEncodeConstants.floatingPointPrimitiveSymbols.contains(memberTarget.type)) {
-            renderableMemberName = "${SwiftTypes.String}($memberName)"
-        }
         XMLNamespaceTraitGenerator?.let {
             writer.write("var $nestedContainerName = $containerName.nestedContainer(keyedBy: \$N.self, forKey: \$N(\"${resolvedMemberName}\"))", ClientRuntimeTypes.Serde.Key, ClientRuntimeTypes.Serde.Key)
-            writer.write("try $nestedContainerName.encode($renderableMemberName, forKey: \$N(\"\"))", ClientRuntimeTypes.Serde.Key)
+            writer.write("try $nestedContainerName.encode($memberName, forKey: \$N(\"\"))", ClientRuntimeTypes.Serde.Key)
             it.render(writer, nestedContainerName)
             it.appendKey(xmlNamespaces)
         } ?: run {
-            writer.write("try $containerName.encode($renderableMemberName, forKey: \$N(\"${resolvedMemberName}\"))", ClientRuntimeTypes.Serde.Key)
+            writer.write("try $containerName.encode($memberName, forKey: \$N(\"${resolvedMemberName}\"))", ClientRuntimeTypes.Serde.Key)
         }
     }
 }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeEncodeXMLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeEncodeXMLGenerator.kt
@@ -13,7 +13,6 @@ import software.amazon.smithy.model.shapes.TimestampShape
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.model.traits.XmlFlattenedTrait
 import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
-import software.amazon.smithy.swift.codegen.SwiftTypes
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.serde.MemberShapeEncodeConstants

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/AddOperationShapes.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/AddOperationShapes.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.traits.XmlNameTrait
 import software.amazon.smithy.swift.codegen.SyntheticClone
 import java.util.logging.Logger
 
@@ -109,6 +110,15 @@ class AddOperationShapes {
                         .build()
                 )
             }
+
+            val xmlName = shape.getTrait<XmlNameTrait>()?.value
+            if (xmlName == null) {
+                // If the operation shape doesn't define an explicit xml name,
+                // then add a xml name trait set to the shape's original name.
+                // This is necessary since we modify the shape's name.
+                builder.addTrait(XmlNameTrait(shape.defaultName()))
+            }
+
             return builder.build() as Shape
         }
     }

--- a/smithy-swift-codegen/src/test/kotlin/ContentMd5MiddlewareTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/ContentMd5MiddlewareTests.kt
@@ -32,7 +32,7 @@ class ContentMd5MiddlewareTests {
                     operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse>())
                     operation.buildStep.intercept(position: .before, middleware: ClientRuntime.ContentMD5Middleware<IdempotencyTokenWithStructureOutputResponse>())
                     operation.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse>(contentType: "application/xml"))
-                    operation.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse>())
+                    operation.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse>(xmlName: "IdempotencyToken"))
                     operation.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
                     operation.deserializeStep.intercept(position: .before, middleware: ClientRuntime.LoggerMiddleware<IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>(clientLogMode: config.clientLogMode))
                     operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware<IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>())

--- a/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
@@ -144,7 +144,7 @@ class HttpProtocolClientGeneratorTests {
                 operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<AllocateWidgetInput, AllocateWidgetOutputResponse, AllocateWidgetOutputError>())
                 operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<AllocateWidgetInput, AllocateWidgetOutputResponse>())
                 operation.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<AllocateWidgetInput, AllocateWidgetOutputResponse>(contentType: "application/json"))
-                operation.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<AllocateWidgetInput, AllocateWidgetOutputResponse>())
+                operation.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<AllocateWidgetInput, AllocateWidgetOutputResponse>(xmlName: "AllocateWidgetInput"))
                 operation.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
                 operation.deserializeStep.intercept(position: .before, middleware: ClientRuntime.LoggerMiddleware<AllocateWidgetOutputResponse, AllocateWidgetOutputError>(clientLogMode: config.clientLogMode))
                 operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware<AllocateWidgetOutputResponse, AllocateWidgetOutputError>())

--- a/smithy-swift-codegen/src/test/kotlin/HttpProtocolUnitTestRequestGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpProtocolUnitTestRequestGeneratorTests.kt
@@ -95,7 +95,7 @@ class HttpProtocolUnitTestRequestGeneratorTests {
         operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.HeaderMiddleware<SmokeTestInput, SmokeTestOutputResponse>())
         operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.QueryItemMiddleware<SmokeTestInput, SmokeTestOutputResponse>())
         operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<SmokeTestInput, SmokeTestOutputResponse>(contentType: "application/json"))
-        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<SmokeTestInput, SmokeTestOutputResponse>())
+        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<SmokeTestInput, SmokeTestOutputResponse>(xmlName: "SmokeTestRequest"))
         operationStack.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
         operationStack.deserializeStep.intercept(position: .after,
                      middleware: MockDeserializeMiddleware<SmokeTestOutputResponse, SmokeTestOutputError>(
@@ -103,7 +103,7 @@ class HttpProtocolUnitTestRequestGeneratorTests {
             self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
                 XCTAssertNotNil(expectedHttpBody, "The expected HttpBody is nil")
-                self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!) { expectedData, actualData in
+                self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!, encoder) { expectedData, actualData in
                     do {
                         let expectedObj = try decoder.decode(SmokeTestInputBody.self, from: expectedData)
                         let actualObj = try decoder.decode(SmokeTestInputBody.self, from: actualData)
@@ -189,7 +189,7 @@ class HttpProtocolUnitTestRequestGeneratorTests {
             self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
                 XCTAssertNotNil(expectedHttpBody, "The expected HttpBody is nil")
-                self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!) { expectedData, actualData in
+                self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!, encoder) { expectedData, actualData in
                     XCTAssertEqual(expectedData, actualData)
                 }
             })
@@ -317,7 +317,7 @@ class HttpProtocolUnitTestRequestGeneratorTests {
         }
         operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.HeaderMiddleware<SimpleScalarPropertiesInput, SimpleScalarPropertiesOutputResponse>())
         operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<SimpleScalarPropertiesInput, SimpleScalarPropertiesOutputResponse>(contentType: "application/json"))
-        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<SimpleScalarPropertiesInput, SimpleScalarPropertiesOutputResponse>())
+        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<SimpleScalarPropertiesInput, SimpleScalarPropertiesOutputResponse>(xmlName: "SimpleScalarPropertiesInputOutput"))
         operationStack.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
         operationStack.deserializeStep.intercept(position: .after,
                      middleware: MockDeserializeMiddleware<SimpleScalarPropertiesOutputResponse, SimpleScalarPropertiesOutputError>(
@@ -325,7 +325,7 @@ class HttpProtocolUnitTestRequestGeneratorTests {
             self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
                 XCTAssertNotNil(expectedHttpBody, "The expected HttpBody is nil")
-                self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!) { expectedData, actualData in
+                self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!, encoder) { expectedData, actualData in
                     do {
                         let expectedObj = try decoder.decode(SimpleScalarPropertiesInputBody.self, from: expectedData)
                         let actualObj = try decoder.decode(SimpleScalarPropertiesInputBody.self, from: actualData)
@@ -417,7 +417,7 @@ class HttpProtocolUnitTestRequestGeneratorTests {
             self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
                 XCTAssertNotNil(expectedHttpBody, "The expected HttpBody is nil")
-                self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!) { expectedData, actualData in
+                self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!, encoder) { expectedData, actualData in
                     XCTAssertEqual(expectedData, actualData)
                 }
             })
@@ -556,7 +556,7 @@ class HttpProtocolUnitTestRequestGeneratorTests {
             return try await next.handle(context: context, input: input)
         }
         operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<JsonUnionsInput, JsonUnionsOutputResponse>(contentType: "application/json"))
-        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<JsonUnionsInput, JsonUnionsOutputResponse>())
+        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<JsonUnionsInput, JsonUnionsOutputResponse>(xmlName: "UnionInputOutput"))
         operationStack.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
         operationStack.deserializeStep.intercept(position: .after,
                      middleware: MockDeserializeMiddleware<JsonUnionsOutputResponse, JsonUnionsOutputError>(
@@ -564,7 +564,7 @@ class HttpProtocolUnitTestRequestGeneratorTests {
             self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
                 XCTAssertNotNil(expectedHttpBody, "The expected HttpBody is nil")
-                self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!) { expectedData, actualData in
+                self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!, encoder) { expectedData, actualData in
                     do {
                         let expectedObj = try decoder.decode(JsonUnionsInputBody.self, from: expectedData)
                         let actualObj = try decoder.decode(JsonUnionsInputBody.self, from: actualData)
@@ -665,7 +665,7 @@ class HttpProtocolUnitTestRequestGeneratorTests {
             return try await next.handle(context: context, input: input)
         }
         operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<RecursiveShapesInput, RecursiveShapesOutputResponse>(contentType: "application/json"))
-        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<RecursiveShapesInput, RecursiveShapesOutputResponse>())
+        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<RecursiveShapesInput, RecursiveShapesOutputResponse>(xmlName: "RecursiveShapesInputOutput"))
         operationStack.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
         operationStack.deserializeStep.intercept(position: .after,
                      middleware: MockDeserializeMiddleware<RecursiveShapesOutputResponse, RecursiveShapesOutputError>(
@@ -673,7 +673,7 @@ class HttpProtocolUnitTestRequestGeneratorTests {
             self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
                 XCTAssertNotNil(expectedHttpBody, "The expected HttpBody is nil")
-                self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!) { expectedData, actualData in
+                self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!, encoder) { expectedData, actualData in
                     do {
                         let expectedObj = try decoder.decode(RecursiveShapesInputBody.self, from: expectedData)
                         let actualObj = try decoder.decode(RecursiveShapesInputBody.self, from: actualData)
@@ -757,7 +757,7 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                 return try await next.handle(context: context, input: input)
             }
             operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<InlineDocumentInput, InlineDocumentOutputResponse>(contentType: "application/json"))
-            operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<InlineDocumentInput, InlineDocumentOutputResponse>())
+            operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<InlineDocumentInput, InlineDocumentOutputResponse>(xmlName: "InlineDocumentInputOutput"))
             operationStack.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
             operationStack.deserializeStep.intercept(position: .after,
                          middleware: MockDeserializeMiddleware<InlineDocumentOutputResponse, InlineDocumentOutputError>(
@@ -765,7 +765,7 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                 self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                     XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
                     XCTAssertNotNil(expectedHttpBody, "The expected HttpBody is nil")
-                    self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!) { expectedData, actualData in
+                    self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!, encoder) { expectedData, actualData in
                         do {
                             let expectedObj = try decoder.decode(InlineDocumentInputBody.self, from: expectedData)
                             let actualObj = try decoder.decode(InlineDocumentInputBody.self, from: actualData)
@@ -855,7 +855,7 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                 self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                     XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
                     XCTAssertNotNil(expectedHttpBody, "The expected HttpBody is nil")
-                    self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!) { expectedData, actualData in
+                    self.genericAssertEqualHttpBodyData(expectedHttpBody!, actualHttpBody!, encoder) { expectedData, actualData in
                         do {
                             let expectedObj = try decoder.decode(ClientRuntime.Document.self, from: expectedData)
                             let actualObj = try decoder.decode(ClientRuntime.Document.self, from: actualData)

--- a/smithy-swift-codegen/src/test/kotlin/IdempotencyTokenTraitTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/IdempotencyTokenTraitTests.kt
@@ -31,14 +31,14 @@ class IdempotencyTokenTraitTests {
                     operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>())
                     operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse>())
                     operation.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse>(contentType: "application/xml"))
-                    operation.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse>())
+                    operation.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse>(xmlName: "IdempotencyToken"))
                     operation.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
                     operation.deserializeStep.intercept(position: .before, middleware: ClientRuntime.LoggerMiddleware<IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>(clientLogMode: config.clientLogMode))
                     operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware<IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>())
                     let result = try await operation.handleMiddleware(context: context.build(), input: input, next: client.getHandler())
                     return result
                 }
-            
+
             }
             """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/StructEncodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/StructEncodeXMLGenerationTests.kt
@@ -39,13 +39,13 @@ class StructEncodeXMLGenerationTests {
                         try container.encode(byteValue, forKey: ClientRuntime.Key("byteValue"))
                     }
                     if let doubleValue = doubleValue {
-                        try container.encode(Swift.String(doubleValue), forKey: ClientRuntime.Key("DoubleDribble"))
+                        try container.encode(doubleValue, forKey: ClientRuntime.Key("DoubleDribble"))
                     }
                     if let falseBooleanValue = falseBooleanValue {
                         try container.encode(falseBooleanValue, forKey: ClientRuntime.Key("falseBooleanValue"))
                     }
                     if let floatValue = floatValue {
-                        try container.encode(Swift.String(floatValue), forKey: ClientRuntime.Key("floatValue"))
+                        try container.encode(floatValue, forKey: ClientRuntime.Key("floatValue"))
                     }
                     if let integerValue = integerValue {
                         try container.encode(integerValue, forKey: ClientRuntime.Key("integerValue"))

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/UnionEncodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/UnionEncodeXMLGenerationTests.kt
@@ -37,7 +37,7 @@ class UnionEncodeXMLGenerationTests {
                         case let .datavalue(datavalue):
                             try container.encode(datavalue, forKey: ClientRuntime.Key("dataValue"))
                         case let .doublevalue(doublevalue):
-                            try container.encode(Swift.String(doublevalue), forKey: ClientRuntime.Key("doubleValue"))
+                            try container.encode(doublevalue, forKey: ClientRuntime.Key("doubleValue"))
                         case let .mapvalue(mapvalue):
                             var mapValueContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("mapValue"))
                             for (stringKey0, stringValue0) in mapvalue {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes the following XML encoding and decoding issues 
- Incorrect root key when serializing XML
- Incorrect serialized float and double values when value is not a number or infinity

Additionally, this PR improves our serialization tests. 

## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/711

## Description of changes
The root key for XML is now the correct value. Previously, we didn't use the `xmlName` trait if one existed, nor did we account for the fact that our local swift models do not have the same name as their counterparts defined in the smithy model. This PR ensures that we now use the value defined by the `xmlName` trait (if one exists). it also sets the value of the `xmlName` trait to the shape's original name (as defined in the smithy model) if the shape doesn't define it's own explicit `xmlName`. This allows us to different name in swift code for the corresponding structure. 

Previously, we encoded floats and doubles as strings in XML and never defined handling for when the value is not-a-number or infinity. This PR encodes floats and doubles as is and defines how they should be encoded when the value is not-a-number or infinity (according to the smithy spec)

Lastly, this PR improves the accuracy of our serialization tests. It adds a check that verifies the serialized data matches the expected data. Previously, we would simply check that we could decode the data that we encoded which can produce many false-positives.



## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.