### PR TITLE
chore: bump CRT to 0.4.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "SmithyTestUtil", targets: ["SmithyTestUtil"])
     ],
     dependencies: [
-        .package(url: "https://github.com/awslabs/aws-crt-swift.git", from: "0.3.1"),
+        .package(url: "https://github.com/awslabs/aws-crt-swift.git", .exactItem("0.4.0")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/MaxDesiatov/XMLCoder.git", from: "0.13.0")
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "SmithyTestUtil", targets: ["SmithyTestUtil"])
     ],
     dependencies: [
-        .package(url: "https://github.com/awslabs/aws-crt-swift.git", .exactItem("0.4.0")),
+        .package(url: "https://github.com/awslabs/aws-crt-swift.git", .exact("0.4.0")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/MaxDesiatov/XMLCoder.git", from: "0.13.0")
     ],


### PR DESCRIPTION
## Description of changes
Use aws-crt-swift version 0.4.0, change version to locked rather than floating to next major

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.