### PR TITLE
fix: Fix encoding of nested maps when generating encoders

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeDecodeGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeDecodeGenerator.kt
@@ -71,15 +71,17 @@ abstract class MemberShapeDecodeGenerator(
     private fun determineSymbolForShape(currShape: Shape, topLevel: Boolean): String {
         var mappedSymbol = when (currShape) {
             is MapShape -> {
+                val mapIsSparse = currShape.hasTrait<SparseTrait>()
                 val targetShape = ctx.model.expectShape(currShape.value.target)
                 val valueEvaluated = determineSymbolForShape(targetShape, topLevel)
-                val terminator = if (topLevel) "?" else ""
+                val terminator = if (topLevel || mapIsSparse) "?" else ""
                 "[${SwiftTypes.String}: $valueEvaluated$terminator]"
             }
             is ListShape -> {
+                val listIsSparse = currShape.hasTrait<SparseTrait>()
                 val targetShape = ctx.model.expectShape(currShape.member.target)
                 val nestedShape = determineSymbolForShape(targetShape, topLevel)
-                val terminator = if (topLevel) "?" else ""
+                val terminator = if (topLevel || listIsSparse) "?" else ""
                 "[$nestedShape$terminator]"
             }
             is SetShape -> {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeEncodeGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeEncodeGenerator.kt
@@ -7,7 +7,6 @@ package software.amazon.smithy.swift.codegen.integration.serde.json
 import software.amazon.smithy.model.knowledge.NullableIndex
 import software.amazon.smithy.model.shapes.BlobShape
 import software.amazon.smithy.model.shapes.CollectionShape
-import software.amazon.smithy.model.shapes.ListShape
 import software.amazon.smithy.model.shapes.MapShape
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.Shape
@@ -153,10 +152,7 @@ abstract class MemberShapeEncodeGenerator(
                 }
             }
             when (targetShape) {
-                is CollectionShape -> {
-                    renderEncodeListMember(targetShape, iteratorName, topLevelContainerName, level + 1)
-                }
-                is MapShape -> {
+                is CollectionShape, is MapShape -> {
                     renderEncodeListMember(targetShape, iteratorName, topLevelContainerName, level + 1)
                 }
                 else -> {
@@ -225,21 +221,8 @@ abstract class MemberShapeEncodeGenerator(
                 }
             }
             when (target) {
-                is CollectionShape -> {
-                    renderEncodeMapMember(
-                        target,
-                        valueIterator,
-                        topLevelContainerName,
-                        level + 1
-                    )
-                }
-                is MapShape -> {
-                    renderEncodeMapMember(
-                        target,
-                        valueIterator,
-                        topLevelContainerName,
-                        level + 1
-                    )
+                is CollectionShape, is MapShape -> {
+                    renderEncodeMapMember(target, valueIterator, topLevelContainerName, level + 1)
                 }
                 else -> {
                     val keyEnumName = "${ClientRuntimeTypes.Serde.Key}(stringValue: $dictKey$level)"

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeEncodeGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeEncodeGenerator.kt
@@ -157,7 +157,7 @@ abstract class MemberShapeEncodeGenerator(
                 }
                 else -> {
                     val isBoxed = ctx.symbolProvider.toSymbol(targetShape).isBoxed() && targetShape.hasTrait<SparseTrait>()
-                    if (isBoxed && level == 0) {
+                    if (isBoxed) {
                         writer.openBlock("if let \$L = \$L {", "}", iteratorName, iteratorName) {
                             renderSimpleShape(targetShape, iteratorName, topLevelContainerName, null, isBoxed)
                         }
@@ -190,7 +190,7 @@ abstract class MemberShapeEncodeGenerator(
             }
             else -> {
                 val isBoxed = ctx.symbolProvider.toSymbol(targetShape).isBoxed() && targetShape.hasTrait<SparseTrait>()
-                if (isBoxed) {
+                if (isBoxed && level == 0) {
                     writer.openBlock("if let \$L = \$L {", "}", memberName, memberName) {
                         renderSimpleShape(targetShape, memberName, containerName, keyName, isBoxed)
                     }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeEncodeGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeEncodeGenerator.kt
@@ -157,7 +157,7 @@ abstract class MemberShapeEncodeGenerator(
                 }
                 else -> {
                     val isBoxed = ctx.symbolProvider.toSymbol(targetShape).isBoxed() && targetShape.hasTrait<SparseTrait>()
-                    if (isBoxed) {
+                    if (isBoxed && level == 0) {
                         writer.openBlock("if let \$L = \$L {", "}", iteratorName, iteratorName) {
                             renderSimpleShape(targetShape, iteratorName, topLevelContainerName, null, isBoxed)
                         }

--- a/smithy-swift-codegen/src/test/kotlin/StructDecodeGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/StructDecodeGenerationTests.kt
@@ -77,8 +77,7 @@ class StructDecodeGenerationTests {
     fun `it decodes nested documents with aggregate shapes`() {
         val contents = getModelFileContents("example", "Nested4+Codable.swift", newTestContext.manifest)
         contents.shouldSyntacticSanityCheck()
-        val expectedContents =
-            """
+        val expectedContents = """
             extension ExampleClientTypes.Nested4: Swift.Codable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case intList
@@ -91,14 +90,14 @@ class StructDecodeGenerationTests {
                     var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
                     if let intList = intList {
                         var intListContainer = encodeContainer.nestedUnkeyedContainer(forKey: .intList)
-                        for intlist0 in intList {
-                            try intListContainer.encode(intlist0)
+                        for integer0 in intList {
+                            try intListContainer.encode(integer0)
                         }
                     }
                     if let intMap = intMap {
                         var intMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .intMap)
-                        for (dictKey0, intmap0) in intMap {
-                            try intMapContainer.encode(intmap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
+                        for (dictKey0, intMap0) in intMap {
+                            try intMapContainer.encode(intMap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
                         }
                     }
                     if let member1 = self.member1 {
@@ -106,8 +105,11 @@ class StructDecodeGenerationTests {
                     }
                     if let stringMap = stringMap {
                         var stringMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .stringMap)
-                        for (dictKey0, nestedstringmap0) in stringMap {
-                            try stringMapContainer.encode(nestedstringmap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
+                        for (dictKey0, nestedStringMap0) in stringMap {
+                            var nestedStringMap0Container = stringMapContainer.nestedUnkeyedContainer(forKey: ClientRuntime.Key(stringValue: dictKey0))
+                            for string1 in nestedStringMap0 {
+                                try nestedStringMap0Container.encode(string1)
+                            }
                         }
                     }
                 }
@@ -158,7 +160,7 @@ class StructDecodeGenerationTests {
                     stringMap = stringMapDecoded0
                 }
             }
-            """.trimIndent()
+        """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
     }
 

--- a/smithy-swift-codegen/src/test/kotlin/StructEncodeGenerationIsolatedTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/StructEncodeGenerationIsolatedTests.kt
@@ -96,8 +96,7 @@ class StructEncodeGenerationIsolatedTests {
         val contents = getFileContents(context.manifest, "/example/models/JsonListsInput+Encodable.swift")
         contents.shouldSyntacticSanityCheck()
 
-        val expectedContents =
-            """
+        val expectedContents = """
             extension JsonListsInput: Swift.Encodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case nestedStringList
@@ -109,28 +108,28 @@ class StructEncodeGenerationIsolatedTests {
                     var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
                     if let nestedStringList = nestedStringList {
                         var nestedStringListContainer = encodeContainer.nestedUnkeyedContainer(forKey: .nestedStringList)
-                        for nestedstringlist0 in nestedStringList {
-                            var nestedstringlist0Container = nestedStringListContainer.nestedUnkeyedContainer()
-                            for stringlist1 in nestedstringlist0 {
-                                try nestedstringlist0Container.encode(stringlist1)
+                        for stringlist0 in nestedStringList {
+                            var stringlist0Container = nestedStringListContainer.nestedUnkeyedContainer()
+                            for string1 in stringlist0 {
+                                try stringlist0Container.encode(string1)
                             }
                         }
                     }
                     if let stringList = stringList {
                         var stringListContainer = encodeContainer.nestedUnkeyedContainer(forKey: .stringList)
-                        for stringlist0 in stringList {
-                            try stringListContainer.encode(stringlist0)
+                        for string0 in stringList {
+                            try stringListContainer.encode(string0)
                         }
                     }
                     if let stringSet = stringSet {
                         var stringSetContainer = encodeContainer.nestedUnkeyedContainer(forKey: .stringSet)
-                        for stringset0 in stringSet {
-                            try stringSetContainer.encode(stringset0)
+                        for string0 in stringSet {
+                            try stringSetContainer.encode(string0)
                         }
                     }
                 }
             }
-            """.trimIndent()
+        """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
     }
 

--- a/smithy-swift-codegen/src/test/kotlin/StructEncodeGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/StructEncodeGenerationTests.kt
@@ -71,8 +71,7 @@ class StructEncodeGenerationTests {
     fun `it encodes nested documents with aggregate shapes`() {
         val contents = getModelFileContents("example", "Nested4+Codable.swift", newTestContext.manifest)
         contents.shouldSyntacticSanityCheck()
-        val expectedContents =
-            """
+        val expectedContents = """
             extension Nested4: Swift.Codable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case intList
@@ -85,14 +84,14 @@ class StructEncodeGenerationTests {
                     var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
                     if let intList = intList {
                         var intListContainer = encodeContainer.nestedUnkeyedContainer(forKey: .intList)
-                        for intlist0 in intList {
-                            try intListContainer.encode(intlist0)
+                        for integer0 in intList {
+                            try intListContainer.encode(integer0)
                         }
                     }
                     if let intMap = intMap {
                         var intMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .intMap)
-                        for (dictKey0, intmap0) in intMap {
-                            try intMapContainer.encode(intmap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
+                        for (dictKey0, intMap0) in intMap {
+                            try intMapContainer.encode(intMap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
                         }
                     }
                     if let member1 = self.member1 {
@@ -100,8 +99,11 @@ class StructEncodeGenerationTests {
                     }
                     if let stringMap = stringMap {
                         var stringMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .stringMap)
-                        for (dictKey0, nestedstringmap0) in stringMap {
-                            try stringMapContainer.encode(nestedstringmap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
+                        for (dictKey0, nestedStringMap0) in stringMap {
+                            var nestedStringMap0Container = stringMapContainer.nestedUnkeyedContainer(forKey: ClientRuntime.Key(stringValue: dictKey0))
+                            for string1 in nestedStringMap0 {
+                                try nestedStringMap0Container.encode(string1)
+                            }
                         }
                     }
                 }
@@ -152,7 +154,7 @@ class StructEncodeGenerationTests {
                     stringMap = stringMapDecoded0
                 }
             }
-            """.trimIndent()
+        """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
     }
 
@@ -160,8 +162,7 @@ class StructEncodeGenerationTests {
     fun `it provides encodable conformance to operation inputs with timestamps`() {
         val contents = getModelFileContents("example", "TimestampInputInput+Encodable.swift", newTestContext.manifest)
         contents.shouldSyntacticSanityCheck()
-        val expectedContents =
-            """
+        val expectedContents = """
             extension TimestampInputInput: Swift.Encodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case dateTime
@@ -191,13 +192,13 @@ class StructEncodeGenerationTests {
                     }
                     if let timestampList = timestampList {
                         var timestampListContainer = encodeContainer.nestedUnkeyedContainer(forKey: .timestampList)
-                        for timestamplist0 in timestampList {
-                            try timestampListContainer.encodeTimestamp(timestamplist0, format: .dateTime)
+                        for timestamp0 in timestampList {
+                            try timestampListContainer.encodeTimestamp(timestamp0, format: .dateTime)
                         }
                     }
                 }
             }
-            """.trimIndent()
+        """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
     }
 
@@ -205,8 +206,7 @@ class StructEncodeGenerationTests {
     fun `it encodes maps correctly`() {
         val contents = getModelFileContents("example", "MapInputInput+Encodable.swift", newTestContext.manifest)
         contents.shouldSyntacticSanityCheck()
-        val expectedContents =
-            """
+        val expectedContents = """
             extension MapInputInput: Swift.Encodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case blobMap
@@ -220,37 +220,37 @@ class StructEncodeGenerationTests {
                     var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
                     if let blobMap = blobMap {
                         var blobMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .blobMap)
-                        for (dictKey0, blobmap0) in blobMap {
-                            try blobMapContainer.encode(blobmap0.base64EncodedString(), forKey: ClientRuntime.Key(stringValue: dictKey0))
+                        for (dictKey0, blobMap0) in blobMap {
+                            try blobMapContainer.encode(blobMap0.base64EncodedString(), forKey: ClientRuntime.Key(stringValue: dictKey0))
                         }
                     }
                     if let dateMap = dateMap {
                         var dateMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .dateMap)
-                        for (dictKey0, datemap0) in dateMap {
-                            try dateMapContainer.encodeTimestamp(datemap0, format: .httpDate, forKey: ClientRuntime.Key(stringValue: dictKey0))
+                        for (dictKey0, dateMap0) in dateMap {
+                            try dateMapContainer.encodeTimestamp(dateMap0, format: .dateTime, forKey: ClientRuntime.Key(stringValue: dictKey0))
                         }
                     }
                     if let enumMap = enumMap {
                         var enumMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .enumMap)
-                        for (dictKey0, enummap0) in enumMap {
-                            try enumMapContainer.encode(enummap0.rawValue, forKey: ClientRuntime.Key(stringValue: dictKey0))
+                        for (dictKey0, enumMap0) in enumMap {
+                            try enumMapContainer.encode(enumMap0.rawValue, forKey: ClientRuntime.Key(stringValue: dictKey0))
                         }
                     }
                     if let intMap = intMap {
                         var intMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .intMap)
-                        for (dictKey0, intmap0) in intMap {
-                            try intMapContainer.encode(intmap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
+                        for (dictKey0, intMap0) in intMap {
+                            try intMapContainer.encode(intMap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
                         }
                     }
                     if let structMap = structMap {
                         var structMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .structMap)
-                        for (dictKey0, structmap0) in structMap {
-                            try structMapContainer.encode(structmap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
+                        for (dictKey0, structMap0) in structMap {
+                            try structMapContainer.encode(structMap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
                         }
                     }
                 }
             }
-            """.trimIndent()
+        """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
     }
 
@@ -381,8 +381,7 @@ class StructEncodeGenerationTests {
     fun `it encodes structure with sparse list`() {
         val contents = getModelFileContents("example", "JsonListsInput+Encodable.swift", newTestContext.manifest)
         contents.shouldSyntacticSanityCheck()
-        val expectedContents =
-            """
+        val expectedContents = """
 extension JsonListsInput: Swift.Encodable {
     enum CodingKeys: Swift.String, Swift.CodingKey {
         case booleanList
@@ -398,52 +397,56 @@ extension JsonListsInput: Swift.Encodable {
         var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
         if let booleanList = booleanList {
             var booleanListContainer = encodeContainer.nestedUnkeyedContainer(forKey: .booleanList)
-            for booleanlist0 in booleanList {
-                try booleanListContainer.encode(booleanlist0)
+            for boolean0 in booleanList {
+                try booleanListContainer.encode(boolean0)
             }
         }
         if let integerList = integerList {
             var integerListContainer = encodeContainer.nestedUnkeyedContainer(forKey: .integerList)
-            for integerlist0 in integerList {
-                try integerListContainer.encode(integerlist0)
+            for integer0 in integerList {
+                try integerListContainer.encode(integer0)
             }
         }
         if let nestedStringList = nestedStringList {
             var nestedStringListContainer = encodeContainer.nestedUnkeyedContainer(forKey: .nestedStringList)
-            for nestedstringlist0 in nestedStringList {
-                var nestedstringlist0Container = nestedStringListContainer.nestedUnkeyedContainer()
-                for stringlist1 in nestedstringlist0 {
-                    try nestedstringlist0Container.encode(stringlist1)
+            for stringlist0 in nestedStringList {
+                var stringlist0Container = nestedStringListContainer.nestedUnkeyedContainer()
+                for string1 in stringlist0 {
+                    try stringlist0Container.encode(string1)
                 }
             }
         }
         if let sparseStringList = sparseStringList {
             var sparseStringListContainer = encodeContainer.nestedUnkeyedContainer(forKey: .sparseStringList)
-            for sparsestringlist0 in sparseStringList {
-                try sparseStringListContainer.encode(sparsestringlist0)
+            for string0 in sparseStringList {
+                guard let string0 = string0 else {
+                    try sparseStringListContainer.encodeNil()
+                    continue
+                }
+                try sparseStringListContainer.encode(string0)
             }
         }
         if let stringList = stringList {
             var stringListContainer = encodeContainer.nestedUnkeyedContainer(forKey: .stringList)
-            for stringlist0 in stringList {
-                try stringListContainer.encode(stringlist0)
+            for string0 in stringList {
+                try stringListContainer.encode(string0)
             }
         }
         if let stringSet = stringSet {
             var stringSetContainer = encodeContainer.nestedUnkeyedContainer(forKey: .stringSet)
-            for stringset0 in stringSet {
-                try stringSetContainer.encode(stringset0)
+            for string0 in stringSet {
+                try stringSetContainer.encode(string0)
             }
         }
         if let timestampList = timestampList {
             var timestampListContainer = encodeContainer.nestedUnkeyedContainer(forKey: .timestampList)
-            for timestamplist0 in timestampList {
-                try timestampListContainer.encodeTimestamp(timestamplist0, format: .dateTime)
+            for timestamp0 in timestampList {
+                try timestampListContainer.encodeTimestamp(timestamp0, format: .dateTime)
             }
         }
     }
 }
-            """.trimIndent()
+        """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
     }
 
@@ -451,8 +454,7 @@ extension JsonListsInput: Swift.Encodable {
     fun `it encodes structure with sparse map`() {
         val contents = getModelFileContents("example", "JsonMapsInput+Encodable.swift", newTestContext.manifest)
         contents.shouldSyntacticSanityCheck()
-        val expectedContents =
-            """
+        val expectedContents = """
 extension JsonMapsInput: Swift.Encodable {
     enum CodingKeys: Swift.String, Swift.CodingKey {
         case denseBooleanMap
@@ -469,55 +471,71 @@ extension JsonMapsInput: Swift.Encodable {
         var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
         if let denseBooleanMap = denseBooleanMap {
             var denseBooleanMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .denseBooleanMap)
-            for (dictKey0, densebooleanmap0) in denseBooleanMap {
-                try denseBooleanMapContainer.encode(densebooleanmap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
+            for (dictKey0, denseBooleanMap0) in denseBooleanMap {
+                try denseBooleanMapContainer.encode(denseBooleanMap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
             }
         }
         if let denseNumberMap = denseNumberMap {
             var denseNumberMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .denseNumberMap)
-            for (dictKey0, densenumbermap0) in denseNumberMap {
-                try denseNumberMapContainer.encode(densenumbermap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
+            for (dictKey0, denseNumberMap0) in denseNumberMap {
+                try denseNumberMapContainer.encode(denseNumberMap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
             }
         }
         if let denseStringMap = denseStringMap {
             var denseStringMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .denseStringMap)
-            for (dictKey0, densestringmap0) in denseStringMap {
-                try denseStringMapContainer.encode(densestringmap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
+            for (dictKey0, denseStringMap0) in denseStringMap {
+                try denseStringMapContainer.encode(denseStringMap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
             }
         }
         if let denseStructMap = denseStructMap {
             var denseStructMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .denseStructMap)
-            for (dictKey0, densestructmap0) in denseStructMap {
-                try denseStructMapContainer.encode(densestructmap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
+            for (dictKey0, denseStructMap0) in denseStructMap {
+                try denseStructMapContainer.encode(denseStructMap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
             }
         }
         if let sparseBooleanMap = sparseBooleanMap {
             var sparseBooleanMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .sparseBooleanMap)
-            for (dictKey0, sparsebooleanmap0) in sparseBooleanMap {
-                try sparseBooleanMapContainer.encode(sparsebooleanmap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
+            for (dictKey0, sparseBooleanMap0) in sparseBooleanMap {
+                guard let sparseBooleanMap0 = sparseBooleanMap0 else {
+                    try sparseBooleanMapContainer.encodeNil(forKey: ClientRuntime.Key(stringValue: dictKey0))
+                    continue
+                }
+                try sparseBooleanMapContainer.encode(sparseBooleanMap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
             }
         }
         if let sparseNumberMap = sparseNumberMap {
             var sparseNumberMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .sparseNumberMap)
-            for (dictKey0, sparsenumbermap0) in sparseNumberMap {
-                try sparseNumberMapContainer.encode(sparsenumbermap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
+            for (dictKey0, sparseNumberMap0) in sparseNumberMap {
+                guard let sparseNumberMap0 = sparseNumberMap0 else {
+                    try sparseNumberMapContainer.encodeNil(forKey: ClientRuntime.Key(stringValue: dictKey0))
+                    continue
+                }
+                try sparseNumberMapContainer.encode(sparseNumberMap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
             }
         }
         if let sparseStringMap = sparseStringMap {
             var sparseStringMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .sparseStringMap)
-            for (dictKey0, sparsestringmap0) in sparseStringMap {
-                try sparseStringMapContainer.encode(sparsestringmap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
+            for (dictKey0, sparseStringMap0) in sparseStringMap {
+                guard let sparseStringMap0 = sparseStringMap0 else {
+                    try sparseStringMapContainer.encodeNil(forKey: ClientRuntime.Key(stringValue: dictKey0))
+                    continue
+                }
+                try sparseStringMapContainer.encode(sparseStringMap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
             }
         }
         if let sparseStructMap = sparseStructMap {
             var sparseStructMapContainer = encodeContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .sparseStructMap)
-            for (dictKey0, sparsestructmap0) in sparseStructMap {
-                try sparseStructMapContainer.encode(sparsestructmap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
+            for (dictKey0, sparseStructMap0) in sparseStructMap {
+                guard let sparseStructMap0 = sparseStructMap0 else {
+                    try sparseStructMapContainer.encodeNil(forKey: ClientRuntime.Key(stringValue: dictKey0))
+                    continue
+                }
+                try sparseStructMapContainer.encode(sparseStructMap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
             }
         }
     }
 }
-            """.trimIndent()
+        """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
     }
 

--- a/smithy-swift-codegen/src/test/kotlin/UnionDecodeGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/UnionDecodeGeneratorTests.kt
@@ -64,8 +64,7 @@ class UnionDecodeGeneratorTests {
     fun `it decodes a union with various member shape types`() {
         val contents = getModelFileContents("example", "MyUnion+Codable.swift", newTestContext.manifest)
         contents.shouldSyntacticSanityCheck()
-        val expectedContents =
-            """
+        val expectedContents = """
             extension ExampleClientTypes.MyUnion: Swift.Codable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case blobvalue = "blobValue"
@@ -94,13 +93,13 @@ class UnionDecodeGeneratorTests {
                             try container.encodeTimestamp(inheritedtimestamp, format: .httpDate, forKey: .inheritedtimestamp)
                         case let .listvalue(listvalue):
                             var listvalueContainer = container.nestedUnkeyedContainer(forKey: .listvalue)
-                            for stringlist0 in listvalue {
-                                try listvalueContainer.encode(stringlist0)
+                            for string0 in listvalue {
+                                try listvalueContainer.encode(string0)
                             }
                         case let .mapvalue(mapvalue):
                             var mapvalueContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .mapvalue)
-                            for (dictKey0, stringmap0) in mapvalue {
-                                try mapvalueContainer.encode(stringmap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
+                            for (dictKey0, stringMap0) in mapvalue {
+                                try mapvalueContainer.encode(stringMap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
                             }
                         case let .numbervalue(numbervalue):
                             try container.encode(numbervalue, forKey: .numbervalue)
@@ -188,7 +187,7 @@ class UnionDecodeGeneratorTests {
                     self = .sdkUnknown("")
                 }
             }
-            """.trimIndent()
+        """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
     }
 }

--- a/smithy-swift-codegen/src/test/kotlin/UnionEncodeGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/UnionEncodeGeneratorTests.kt
@@ -70,8 +70,7 @@ class UnionEncodeGeneratorTests {
     fun `it encodes a union with various member shape types`() {
         val contents = getModelFileContents("example", "MyUnion+Codable.swift", newTestContext.manifest)
         contents.shouldSyntacticSanityCheck()
-        val expectedContents =
-            """
+        val expectedContents = """
             extension ExampleClientTypes.MyUnion: Swift.Codable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case blobvalue = "blobValue"
@@ -100,13 +99,13 @@ class UnionEncodeGeneratorTests {
                             try container.encodeTimestamp(inheritedtimestamp, format: .httpDate, forKey: .inheritedtimestamp)
                         case let .listvalue(listvalue):
                             var listvalueContainer = container.nestedUnkeyedContainer(forKey: .listvalue)
-                            for stringlist0 in listvalue {
-                                try listvalueContainer.encode(stringlist0)
+                            for string0 in listvalue {
+                                try listvalueContainer.encode(string0)
                             }
                         case let .mapvalue(mapvalue):
                             var mapvalueContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: .mapvalue)
-                            for (dictKey0, stringmap0) in mapvalue {
-                                try mapvalueContainer.encode(stringmap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
+                            for (dictKey0, stringMap0) in mapvalue {
+                                try mapvalueContainer.encode(stringMap0, forKey: ClientRuntime.Key(stringValue: dictKey0))
                             }
                         case let .numbervalue(numbervalue):
                             try container.encode(numbervalue, forKey: .numbervalue)
@@ -194,7 +193,7 @@ class UnionEncodeGeneratorTests {
                     self = .sdkUnknown("")
                 }
             }
-            """.trimIndent()
+        """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
     }
 

--- a/smithy-swift-codegen/src/test/kotlin/serde/awsjson11/NestedListEncodeJSONGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/awsjson11/NestedListEncodeJSONGenerationTests.kt
@@ -36,30 +36,29 @@ class NestedListEncodeJSONGenerationTests {
         val context = setupTests("Isolated/json11/lists-of-maps-of-lists.smithy", "aws.protocoltests.json#JsonProtocol")
         val contents = getFileContents(context.manifest, "/Example/models/ListOfMapsOperationInput+Encodable.swift")
         contents.shouldSyntacticSanityCheck()
-        val expectedContents =
-            """
-            extension ListOfMapsOperationInput: Swift.Encodable {
-                enum CodingKeys: Swift.String, Swift.CodingKey {
-                    case targetMaps
-                }
-            
-                public func encode(to encoder: Swift.Encoder) throws {
-                    var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
-                    if let targetMaps = targetMaps {
-                        var targetMapsContainer = encodeContainer.nestedUnkeyedContainer(forKey: .targetMaps)
-                        for targetmaps0 in targetMaps {
-                            var targetmaps0Container = targetMapsContainer.nestedContainer(keyedBy: ClientRuntime.Key.self)
-                            for (dictKey1, targetmap1) in targetmaps0 {
-                                var targetmap1Container = targetmaps0Container.nestedUnkeyedContainer(forKey: ClientRuntime.Key(dictKey1))
-                                for targetmapvaluelist2 in targetmap1 {
-                                    try targetmap1Container.encode(targetmapvaluelist2)
-                                }
+        val expectedContents = """
+        extension ListOfMapsOperationInput: Swift.Encodable {
+            enum CodingKeys: Swift.String, Swift.CodingKey {
+                case targetMaps
+            }
+        
+            public func encode(to encoder: Swift.Encoder) throws {
+                var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
+                if let targetMaps = targetMaps {
+                    var targetMapsContainer = encodeContainer.nestedUnkeyedContainer(forKey: .targetMaps)
+                    for targetmap0 in targetMaps {
+                        var targetmap0Container = targetMapsContainer.nestedContainer(keyedBy: ClientRuntime.Key.self)
+                        for (dictKey1, targetMap1) in targetmap0 {
+                            var targetMap1Container = targetmap0Container.nestedUnkeyedContainer(forKey: ClientRuntime.Key(stringValue: dictKey1))
+                            for string2 in targetMap1 {
+                                try targetMap1Container.encode(string2)
                             }
                         }
                     }
                 }
             }
-            """.trimIndent()
+        }
+        """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
     }
     private fun setupTests(smithyFile: String, serviceShapeId: String): TestContext {

--- a/smithy-swift-codegen/src/test/kotlin/serde/awsjson11/NestedListEncodeJSONGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/awsjson11/NestedListEncodeJSONGenerationTests.kt
@@ -37,27 +37,27 @@ class NestedListEncodeJSONGenerationTests {
         val contents = getFileContents(context.manifest, "/Example/models/ListOfMapsOperationInput+Encodable.swift")
         contents.shouldSyntacticSanityCheck()
         val expectedContents = """
-        extension ListOfMapsOperationInput: Swift.Encodable {
-            enum CodingKeys: Swift.String, Swift.CodingKey {
-                case targetMaps
-            }
-        
-            public func encode(to encoder: Swift.Encoder) throws {
-                var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
-                if let targetMaps = targetMaps {
-                    var targetMapsContainer = encodeContainer.nestedUnkeyedContainer(forKey: .targetMaps)
-                    for targetmap0 in targetMaps {
-                        var targetmap0Container = targetMapsContainer.nestedContainer(keyedBy: ClientRuntime.Key.self)
-                        for (dictKey1, targetMap1) in targetmap0 {
-                            var targetMap1Container = targetmap0Container.nestedUnkeyedContainer(forKey: ClientRuntime.Key(stringValue: dictKey1))
-                            for string2 in targetMap1 {
-                                try targetMap1Container.encode(string2)
+            extension ListOfMapsOperationInput: Swift.Encodable {
+                enum CodingKeys: Swift.String, Swift.CodingKey {
+                    case targetMaps
+                }
+            
+                public func encode(to encoder: Swift.Encoder) throws {
+                    var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
+                    if let targetMaps = targetMaps {
+                        var targetMapsContainer = encodeContainer.nestedUnkeyedContainer(forKey: .targetMaps)
+                        for targetmap0 in targetMaps {
+                            var targetmap0Container = targetMapsContainer.nestedContainer(keyedBy: ClientRuntime.Key.self)
+                            for (dictKey1, targetMap1) in targetmap0 {
+                                var targetMap1Container = targetmap0Container.nestedUnkeyedContainer(forKey: ClientRuntime.Key(stringValue: dictKey1))
+                                for string2 in targetMap1 {
+                                    try targetMap1Container.encode(string2)
+                                }
                             }
                         }
                     }
                 }
             }
-        }
         """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
     }


### PR DESCRIPTION
## Issue \#
Fixes https://github.com/awslabs/aws-sdk-swift/issues/747

## Description of changes

With the introduction of the `AWSSecurityLake` service, an SDK compile error was encountered when compiling the generated `encode(to:)` method for a model containing this property:
```
        enableAllDimensions: [Swift.String:[Swift.String:[Swift.String]]]? = nil,
```

After investigation it was discovered that the SDK was not generating correct code for nested maps & collections, so the code generation for encoding nested Smithy Maps & Lists was corrected.

Correcting that code exposed a compile error on code for serializing & deserializing `@sparse` collections (i.e. arrays where elements my be nil, or dictionaries where values may be nil).  Codegen was also corrected for `@sparse` data types.

New local protocol tests are being added in https://github.com/awslabs/aws-sdk-swift/pull/779 to verify that these changes build correct Codable methods for nested and/or sparse collections.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.