### PR TITLE
fix: Use correct var name in AND expression

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/waiters/JMESPathVisitor.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/waiters/JMESPathVisitor.kt
@@ -155,10 +155,10 @@ class JMESPathVisitor(
     // Performs a Boolean "and" of the left & right expressions
     // A Swift compile error will result if both left & right aren't Booleans.
     override fun visitAnd(expression: AndExpression): JMESVariable {
-        val leftExp = expression.left!!.accept(this)
-        val rightExp = expression.right!!.accept(this)
+        val leftVar = expression.left!!.accept(this)
+        val rightVar = expression.right!!.accept(this)
         val andResultVar = JMESVariable("andResult", false, boolShape)
-        return addTempVar(andResultVar, "\$L && \$L", leftExp, rightExp)
+        return addTempVar(andResultVar, "\$L && \$L", leftVar.name, rightVar.name)
     }
 
     // Perform a comparison of two values.


### PR DESCRIPTION
## Description of changes
Fixes rendering of JMESPath AND expressions, which render improperly because the debug description of the `JMESVariable`s being ANDed is being inserted into Swift code instead of the variable name.

I will write an acceptor functional test using AND in the `aws-sdk-swift` repo.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.