### PR TITLE
fix: Correct Swift compile errors for comparison expressions

### DIFF
--- a/Packages/ClientRuntime/Sources/Waiters/JMESUtils.swift
+++ b/Packages/ClientRuntime/Sources/Waiters/JMESUtils.swift
@@ -35,15 +35,17 @@ public enum JMESUtils {
         return comparator(lhs, rhs)
     }
 
-// Functions for comparing Int to Int.
+// Functions for comparing Int to Int.  Double comparators are used since Int has
+// extra overloads on `==` that prevent it from resolving correctly, and Ints compared
+// to Doubles are already compared as Doubles anyway.
 
-    public static func compare(_ lhs: Int?, _ comparator: (Int?, Int?) -> Bool, _ rhs: Int?) -> Bool {
-        comparator(lhs, rhs)
+    public static func compare(_ lhs: Int?, _ comparator: (Double?, Double?) -> Bool, _ rhs: Int?) -> Bool {
+        comparator(lhs.map { Double($0) }, rhs.map { Double($0) })
     }
 
-    public static func compare(_ lhs: Int?, _ comparator: (Int, Int) -> Bool, _ rhs: Int?) -> Bool {
+    public static func compare(_ lhs: Int?, _ comparator: (Double, Double) -> Bool, _ rhs: Int?) -> Bool {
         guard let lhs = lhs, let rhs = rhs else { return false }
-        return comparator(lhs, rhs)
+        return comparator(Double(lhs), Double(rhs))
     }
 
 // Function for comparing String to String.

--- a/Packages/ClientRuntime/Tests/WaiterTests/JMESUtilsTests.swift
+++ b/Packages/ClientRuntime/Tests/WaiterTests/JMESUtilsTests.swift
@@ -1,0 +1,165 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+@testable import ClientRuntime
+
+class JMESUtilsTests: XCTestCase {
+
+    // MARK: - Equatable
+
+    // Note that Swift has trouble resolving the `!=` operator
+    // for `Double?`, `Double?` operand types (not for any other type).
+    // Codegen will translate `!=` into `==` and negate the expression
+    // to avoid a compile failure.
+    //
+    // Hence `Int` (which uses `Double` comparators) and `Double` are
+    // not tested with `!=` below.
+
+    func test_equateInt_handlesOptionalityCombos() async throws {
+        let lhs: Int? = 1
+        let rhs: Int? = 2
+        XCTAssertFalse(JMESUtils.compare(lhs, ==, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs!, ==, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs, ==, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs!, ==, rhs!))
+    }
+
+    func test_equateDouble_handlesOptionalityCombos() async throws {
+        let lhs: Double? = 1.0
+        let rhs: Double? = 2.0
+        XCTAssertFalse(JMESUtils.compare(lhs, ==, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs!, ==, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs, ==, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs!, ==, rhs!))
+    }
+
+    func test_equateString_handlesOptionalityCombos() async throws {
+        let lhs: String? = "a"
+        let rhs: String? = "b"
+        XCTAssertFalse(JMESUtils.compare(lhs, ==, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs!, ==, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs, ==, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs!, ==, rhs!))
+        XCTAssertTrue(JMESUtils.compare(lhs, !=, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs!, !=, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs, !=, rhs!))
+        XCTAssertTrue(JMESUtils.compare(lhs!, !=, rhs!))
+    }
+
+    func test_equateBool_handlesOptionalityCombos() async throws {
+        let lhs: Bool? = true
+        let rhs: Bool? = false
+        XCTAssertFalse(JMESUtils.compare(lhs, ==, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs!, ==, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs, ==, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs!, ==, rhs!))
+        XCTAssertTrue(JMESUtils.compare(lhs, !=, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs!, !=, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs, !=, rhs!))
+        XCTAssertTrue(JMESUtils.compare(lhs!, !=, rhs!))
+    }
+
+    func test_equateIntToDouble_handlesOptionalityCombos() async throws {
+        let lhs: Int? = 1
+        let rhs: Double? = 2.0
+        XCTAssertFalse(JMESUtils.compare(lhs, ==, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs!, ==, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs, ==, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs!, ==, rhs!))
+    }
+
+    func test_equateStringToRawRepresentable_handlesOptionalityCombos() async throws {
+        let lhs: String? = "a"
+        let rhs: Stringed? = Stringed(rawValue: "b")
+        XCTAssertFalse(JMESUtils.compare(lhs, ==, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs!, ==, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs, ==, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs!, ==, rhs!))
+        XCTAssertTrue(JMESUtils.compare(lhs, !=, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs!, !=, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs, !=, rhs!))
+        XCTAssertTrue(JMESUtils.compare(lhs!, !=, rhs!))
+    }
+
+    // MARK: - Comparable
+
+    func test_compareInt_handlesOptionalityCombos() async throws {
+        let lhs: Int? = 1
+        let rhs: Int? = 2
+        XCTAssertTrue(JMESUtils.compare(lhs, <, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs!, <, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs, <, rhs!))
+        XCTAssertTrue(JMESUtils.compare(lhs!, <, rhs!))
+        XCTAssertTrue(JMESUtils.compare(lhs, <=, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs!, <=, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs, <=, rhs!))
+        XCTAssertTrue(JMESUtils.compare(lhs!, <=, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs, >, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs!, >, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs, >, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs!, >, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs, >=, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs!, >=, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs, >=, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs!, >=, rhs!))
+    }
+
+    func test_compareDouble_handlesOptionalityCombos() async throws {
+        let lhs: Double? = 1.0
+        let rhs: Double? = 2.0
+        XCTAssertTrue(JMESUtils.compare(lhs, <, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs!, <, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs, <, rhs!))
+        XCTAssertTrue(JMESUtils.compare(lhs!, <, rhs!))
+        XCTAssertTrue(JMESUtils.compare(lhs, <=, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs!, <=, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs, <=, rhs!))
+        XCTAssertTrue(JMESUtils.compare(lhs!, <=, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs, >, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs!, >, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs, >, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs!, >, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs, >=, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs!, >=, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs, >=, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs!, >=, rhs!))
+    }
+
+    func test_compareIntToDouble_handlesOptionalityCombos() async throws {
+        let lhs: Int? = 1
+        let rhs: Double? = 2.0
+        XCTAssertTrue(JMESUtils.compare(lhs, <, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs!, <, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs, <, rhs!))
+        XCTAssertTrue(JMESUtils.compare(lhs!, <, rhs!))
+        XCTAssertTrue(JMESUtils.compare(lhs, <=, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs!, <=, rhs))
+        XCTAssertTrue(JMESUtils.compare(lhs, <=, rhs!))
+        XCTAssertTrue(JMESUtils.compare(lhs!, <=, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs, >, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs!, >, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs, >, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs!, >, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs, >=, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs!, >=, rhs))
+        XCTAssertFalse(JMESUtils.compare(lhs, >=, rhs!))
+        XCTAssertFalse(JMESUtils.compare(lhs!, >=, rhs!))
+    }
+}
+
+// Used for tests of Equatable between String and RawRepresentable.
+fileprivate struct Stringed: RawRepresentable {
+    typealias RawValue = String
+
+    let rawValue: String
+
+    init?(rawValue: String) {
+        self.rawValue = rawValue
+    }
+}


### PR DESCRIPTION
## Description of changes
When building the SDK with waiters, it was discovered that JMES compare expressions with integers and `==`, and with doubles and `!=`, fail to compile due to ambiguity in resolving the operator.
- The Integer / `==` problem is resolved by requiring a Double comparator, then converting the Ints to Double before comparison.
- The Double / `!=` problem is resolved by using `!JMESUtils.compare(a, ==, b)` instead of `JMESUtils.compare(a, !=, b)` when inequality is to be tested.

Unit tests have been added to this PR to test compile-time resolution of various arguments to `JMESUtils.compare(_:_:_:)`.  Generated tests for number equality & inequality expressions are being added in a separate PR.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.