### PR TITLE
fix: Adds `HttpBody.isEmpty` to help parse S3 404 errors properly

### DIFF
--- a/Sources/ClientRuntime/Networking/Http/HttpBody.swift
+++ b/Sources/ClientRuntime/Networking/Http/HttpBody.swift
@@ -25,6 +25,18 @@ public extension HttpBody {
             return nil
         }
     }
+    
+    /// Returns true if the http body is `.none` or if the underlying data is nil or is empty.
+    var isEmpty: Bool {
+        switch self {
+        case let .data(data):
+            return data?.isEmpty ?? true
+        case let .stream(stream):
+            return stream.toBytes().getData().isEmpty
+        case .none:
+            return true
+        }
+    }
 }
 
 

--- a/Tests/ClientRuntimeTests/NetworkingTests/HttpBodyTests.swift
+++ b/Tests/ClientRuntimeTests/NetworkingTests/HttpBodyTests.swift
@@ -1,0 +1,46 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AwsCommonRuntimeKit
+@testable import ClientRuntime
+
+class HttpBodyTests: XCTestCase {
+    func testWhenDataIsEmptyThenIsEmptyIsTrue() {
+        let data = Data()
+        let body = HttpBody.data(data)
+        XCTAssertTrue(body.isEmpty)
+    }
+    
+    func testWhenDataIsNilThenIsEmptyIsTrue() {
+        let body = HttpBody.data(nil)
+        XCTAssertTrue(body.isEmpty)
+    }
+    
+    func testWhenDataIsNotEmptyThenIsEmptyIsFalse() {
+        let data = "foo".data(using: .utf8)!
+        let body = HttpBody.data(data)
+        XCTAssertFalse(body.isEmpty)
+    }
+    
+    func testWhenStreamIsEmptyThenIsEmptyIsTrue() {
+        let stream = ByteStream.from(data: Data())
+        let body = HttpBody.stream(stream)
+        XCTAssertTrue(body.isEmpty)
+    }
+    
+    func testWhenStreamIsNotEmptyThenIsEmptyIsFalse() {
+        let stream = ByteStream.from(data: "foo".data(using: .utf8)!)
+        let body = HttpBody.stream(stream)
+        XCTAssertFalse(body.isEmpty)
+    }
+    
+    func testWhenBodyIsNoneThenIsEmptyIsTrue() {
+        let body = HttpBody.none
+        XCTAssertTrue(body.isEmpty)
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes S3 errors failing to parse by providing an accurate definition for `HttpBody.isEmpty`.

## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/761

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.