### PR TITLE
fix: Add WaiterTypedError conformance to ClientError

### DIFF
--- a/Sources/ClientRuntime/Networking/ClientError.swift
+++ b/Sources/ClientRuntime/Networking/ClientError.swift
@@ -42,3 +42,18 @@ public enum ClientError: Error, Equatable {
         }
     }
 }
+
+extension ClientError: WaiterTypedError {
+
+    /// The Smithy identifier, without namespace, for the type of this error, or `nil` if the
+    /// error has no known type.
+    public var waiterErrorType: String? {
+        switch self {
+        case .networkError(let error), .deserializationFailed(let error), .retryError(let error):
+            return (error as? WaiterTypedError)?.waiterErrorType
+        case .crtError, .pathCreationFailed, .queryItemCreationFailed, .serializationFailed,
+            .dataNotFound, .unknownError, .authError:
+            return nil
+        }
+    }
+}

--- a/Tests/ClientRuntimeTests/ClientRuntimeTests/NetworkingTests/ClientErrorTests.swift
+++ b/Tests/ClientRuntimeTests/ClientRuntimeTests/NetworkingTests/ClientErrorTests.swift
@@ -4,14 +4,15 @@
  */
 
 import XCTest
+import AwsCommonRuntimeKit
 @testable import ClientRuntime
 
 class ClientErrorTests: XCTestCase {
     
     func testNetworkErrorInEqualityWithoutDescription() throws {
         enum NetworkError: Error {
-          case actual
-          case expected
+            case actual
+            case expected
         }
         let actualNetworkError = ClientError.networkError(NetworkError.actual)
         let expectedNetworkError = ClientError.networkError(NetworkError.expected)
@@ -21,17 +22,17 @@ class ClientErrorTests: XCTestCase {
     
     func testNetworkErrorInEqualityWithDescription() throws {
         enum NetworkError: Error, CustomStringConvertible {
-          case actual
-          case expected
-        
-          var description: String {
-            switch self {
-            case .actual:
-                return "Actual"
-            case .expected:
-                return "Expected"
+            case actual
+            case expected
+
+            var description: String {
+                switch self {
+                case .actual:
+                    return "Actual"
+                case .expected:
+                    return "Expected"
+                }
             }
-          }
         }
         
         let actualNetworkError = ClientError.networkError(NetworkError.actual)
@@ -42,17 +43,17 @@ class ClientErrorTests: XCTestCase {
     
     func testNetworkErrorEqualityWithDescription() throws {
         enum NetworkError: Error, CustomStringConvertible {
-          case actual
-          case actualCopy
-        
-          var description: String {
-            switch self {
-            case .actual:
-                return "Actual"
-            case .actualCopy:
-                return "Actual"
+            case actual
+            case actualCopy
+
+            var description: String {
+                switch self {
+                case .actual:
+                    return "Actual"
+                case .actualCopy:
+                    return "Actual"
+                }
             }
-          }
         }
         
         let actualNetworkError = ClientError.networkError(NetworkError.actual)
@@ -60,4 +61,87 @@ class ClientErrorTests: XCTestCase {
         
         XCTAssertEqual(actualNetworkError, actualCopyNetworkError)
     }
+
+    // MARK: - WaiterTypedError protocol
+
+    func test_waiterErrorType_returnsErrorTypeForWaitableNetworkError() async throws {
+        let networkError = WaitableError()
+        let subject = ClientError.networkError(networkError)
+        XCTAssertEqual(subject.waiterErrorType, networkError.waiterErrorType)
+    }
+
+    func test_waiterErrorType_returnsNilForNonWaitableNetworkError() async throws {
+        let networkError = NonWaitableError()
+        let subject = ClientError.networkError(networkError)
+        XCTAssertNil(subject.waiterErrorType)
+    }
+
+    func test_waiterErrorType_returnsErrorTypeForWaitableDeserializationError() async throws {
+        let deserializationError = WaitableError()
+        let subject = ClientError.deserializationFailed(deserializationError)
+        XCTAssertEqual(subject.waiterErrorType, deserializationError.waiterErrorType)
+    }
+
+    func test_waiterErrorType_returnsNilForNonWaitableDeserializationError() async throws {
+        let deserializationError = NonWaitableError()
+        let subject = ClientError.deserializationFailed(deserializationError)
+        XCTAssertNil(subject.waiterErrorType)
+    }
+
+    func test_waiterErrorType_returnsErrorTypeForWaitableRetryError() async throws {
+        let retryError = WaitableError()
+        let subject = ClientError.retryError(retryError)
+        XCTAssertEqual(subject.waiterErrorType, retryError.waiterErrorType)
+    }
+
+    func test_waiterErrorType_returnsNilForNonWaitableRetryError() async throws {
+        let retryError = NonWaitableError()
+        let subject = ClientError.retryError(retryError)
+        XCTAssertNil(subject.waiterErrorType)
+    }
+
+    func test_waiterErrorType_returnsNilForCRTError() async throws {
+        let crtError = CRTError(code: 2)
+        let subject = ClientError.crtError(crtError)
+        XCTAssertNil(subject.waiterErrorType)
+    }
+
+    func test_waiterErrorType_returnsNilForPathCreationFailedError() async throws {
+        let subject = ClientError.pathCreationFailed("path creation failed error")
+        XCTAssertNil(subject.waiterErrorType)
+    }
+
+    func test_waiterErrorType_returnsNilForQueryItemCreationFailedError() async throws {
+        let subject = ClientError.queryItemCreationFailed("query item creation failed error")
+        XCTAssertNil(subject.waiterErrorType)
+    }
+
+    func test_waiterErrorType_returnsNilForSerializationFailedError() async throws {
+        let subject = ClientError.serializationFailed("serialization failed error")
+        XCTAssertNil(subject.waiterErrorType)
+    }
+
+    func test_waiterErrorType_returnsNilForDataNotFoundError() async throws {
+        let subject = ClientError.dataNotFound("data not found error")
+        XCTAssertNil(subject.waiterErrorType)
+    }
+
+    func test_waiterErrorType_returnsNilForUnknownError() async throws {
+        let subject = ClientError.unknownError("unknown error")
+        XCTAssertNil(subject.waiterErrorType)
+    }
+
+    func test_waiterErrorType_returnsNilForAuthError() async throws {
+        let subject = ClientError.authError("auth error")
+        XCTAssertNil(subject.waiterErrorType)
+    }
 }
+
+// MARK: - Helper types
+
+fileprivate struct WaitableError: WaiterTypedError {
+
+    public var waiterErrorType: String? { "WaitableType" }
+}
+
+fileprivate struct NonWaitableError: Error {}


### PR DESCRIPTION
## Issue \#
Fixes https://github.com/awslabs/aws-sdk-swift/issues/781

## Description of changes
Under some circumstances, an error received from an operation will be embedded in a `ClientError.retryError()`.  When this happens, a waiter cannot detect the error's type because `ClientError` does not conform to `WaiterTypedError` and does not return the error type of the underlying error it contains.

This PR addresses the problem by adding `WaiterTypedError` conformance to `ClientError` and enabling it to return the error code from the Swift `Error` it contains.  Unit tests are added to `ClientError` as well.

I have tested this with AWS S3 and EC2 waiters, and found it corrects the issue linked above.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.