### PR TITLE
fix: change socketOptions to mutable to allow mutation on iOS and watchOS

### DIFF
--- a/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
@@ -41,7 +41,7 @@ public class CRTClientEngine: HttpClientEngine {
                 serverName: endpoint.host
             )
 
-            let socketOptions = SocketOptions(socketType: .stream)
+            var socketOptions = SocketOptions(socketType: .stream)
     #if os(iOS) || os(watchOS)
             socketOptions.connectTimeoutMs = 30_000
     #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

On iOS and watchOS, SDK fails to build.

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.