### PR TITLE
chore: bump CRT version to 0.5.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "SmithyTestUtil", targets: ["SmithyTestUtil"])
     ],
     dependencies: [
-        .package(url: "https://github.com/awslabs/aws-crt-swift.git", .exact("0.5.4")),
+        .package(url: "https://github.com/awslabs/aws-crt-swift.git", .exact("0.5.5")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/MaxDesiatov/XMLCoder.git", from: "0.13.0")
     ],


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/823

## Description of changes
Bump to latest CRT version in prep for smithy-swift release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.