### PR TITLE
chore: Use containerized swiftlint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,9 @@ jobs:
       - name: Run ktlint
         run: ./gradlew ktlint
   swiftlint:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/realm/swiftlint:0.50.3
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
## Issue \#
Fixes https://github.com/awslabs/aws-sdk-swift/issues/677

## Description of changes
The SwiftLint project now has containerized SwiftLint available for use:
https://github.com/realm/SwiftLint/pkgs/container/swiftlint

Use the latest stable Dockerized SwiftLint version (currently `0.50.3`) to lint this project.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.