### PR TITLE
fix: two Swift compile warnings

### DIFF
--- a/Sources/ClientRuntime/Networking/SdkError.swift
+++ b/Sources/ClientRuntime/Networking/SdkError.swift
@@ -24,7 +24,7 @@ extension SdkError: WaiterTypedError {
         case .service(let error, _):
             return (error as? WaiterTypedError)?.waiterErrorType
         case .client(let error, _):
-            return (error as? WaiterTypedError)?.waiterErrorType
+            return error.waiterErrorType
         case .unknown(let error):
             return (error as? WaiterTypedError)?.waiterErrorType
         }

--- a/Sources/ClientRuntime/Serialization/Encoder/XMLEncoder+Extensions.swift
+++ b/Sources/ClientRuntime/Serialization/Encoder/XMLEncoder+Extensions.swift
@@ -8,7 +8,7 @@ import XMLCoder
 
 public typealias XMLEncoder = XMLCoder.XMLEncoder
 extension XMLEncoder: RequestEncoder {
-    open func encode<T>(_ value: T) throws -> Data where T: Encodable {
+    public func encode<T>(_ value: T) throws -> Data where T: Encodable {
         return try encode(value, withRootKey: nil, rootAttributes: nil, header: nil)
     }
 }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/providers/HttpQueryItemProvider.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/providers/HttpQueryItemProvider.kt
@@ -73,13 +73,9 @@ class HttpQueryItemProvider(
         writer.openBlock("extension \$N: \$N {", "}", inputSymbol, ClientRuntimeTypes.Middleware.Providers.QueryItemProvider) {
             writer.openBlock("public var queryItems: [\$N] {", "}", ClientRuntimeTypes.Core.URLQueryItem) {
                 writer.openBlock("get throws {", "}") {
-                    if (queryLiterals.isNotEmpty() || queryBindings.isNotEmpty()) {
-                        writer.write("var items = [\$N]()", ClientRuntimeTypes.Core.URLQueryItem)
-                        generateQueryItems()
-                        writer.write("return items")
-                    } else {
-                        writer.write("return []")
-                    }
+                    writer.write("var items = [\$N]()", ClientRuntimeTypes.Core.URLQueryItem)
+                    generateQueryItems()
+                    writer.write("return items")
                 }
             }
         }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/providers/HttpQueryItemProvider.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/providers/HttpQueryItemProvider.kt
@@ -73,9 +73,13 @@ class HttpQueryItemProvider(
         writer.openBlock("extension \$N: \$N {", "}", inputSymbol, ClientRuntimeTypes.Middleware.Providers.QueryItemProvider) {
             writer.openBlock("public var queryItems: [\$N] {", "}", ClientRuntimeTypes.Core.URLQueryItem) {
                 writer.openBlock("get throws {", "}") {
-                    writer.write("var items = [\$N]()", ClientRuntimeTypes.Core.URLQueryItem)
-                    generateQueryItems()
-                    writer.write("return items")
+                    if (queryLiterals.isNotEmpty() || queryBindings.isNotEmpty()) {
+                        writer.write("var items = [\$N]()", ClientRuntimeTypes.Core.URLQueryItem)
+                        generateQueryItems()
+                        writer.write("return items")
+                    } else {
+                        writer.write("return []")
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description of changes
Fixes two different Swift compile warnings thrown when building the AWS SDK.
- `SdkError` no longer conditionally casts `ClientError` to `WaiterTypedError` since `WaiterTypedError` always conforms.
- The `encode(_:)` function on `XMLEncoder` is changed from `open` to `public` to fix `Non-'@objc' instance method in extensions cannot be overridden; use 'public' instead`

After this change, the only compile warnings remaining on the SDK service clients are:
- Deprecated model properties
- The query items property is written as a literal `[]` when no items will be added to it (was going to fix this here, but it needs further investigation)

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.