### PR TITLE
chore: bump aws-crt-swift to 0.5.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "SmithyTestUtil", targets: ["SmithyTestUtil"])
     ],
     dependencies: [
-        .package(url: "https://github.com/awslabs/aws-crt-swift.git", .exact("0.5.4")),
+        .package(url: "https://github.com/awslabs/aws-crt-swift.git", .exact("0.5.6")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/MaxDesiatov/XMLCoder.git", from: "0.13.0")
     ],

--- a/Sources/ClientRuntime/Networking/ClientError.swift
+++ b/Sources/ClientRuntime/Networking/ClientError.swift
@@ -7,7 +7,7 @@ import AwsCommonRuntimeKit
 
 public enum ClientError: Error, Equatable {
     case networkError(Error)
-    case crtError(CRTError)
+    case crtError(CommonRunTimeError)
     case pathCreationFailed(String)
     case queryItemCreationFailed(String)
     case serializationFailed(String)

--- a/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
@@ -104,10 +104,7 @@ public class CRTClientEngine: HttpClientEngine {
         let streamReader: StreamReader = DataStreamReader()
 
         let makeStatusCode: (UInt32) -> HttpStatusCode = { statusCode in
-            guard let httpStatusCode = HttpStatusCode(rawValue: Int(statusCode)) else {
-                return .notFound
-            }
-            return httpStatusCode
+            HttpStatusCode(rawValue: Int(statusCode)) ?? .notFound
          }
 
         let requestOptions = HTTPRequestOptions(request: crtRequest) { statusCode, headers in

--- a/Sources/ClientRuntime/Networking/Http/SdkHttpRequest.swift
+++ b/Sources/ClientRuntime/Networking/Http/SdkHttpRequest.swift
@@ -70,6 +70,12 @@ extension SdkHttpRequest: CustomDebugStringConvertible, CustomStringConvertible 
 }
 
 extension SdkHttpRequestBuilder {
+
+    /// Update the builder with the values from the CRT request
+    /// - Parameters:
+    ///   - crtRequest: the CRT request, this can be either a `HTTPRequest` or a `HTTP2Request`
+    ///   - originalRequest: the SDK request that is used to hold the original values
+    /// - Returns: the builder
     public func update(from crtRequest: HTTPRequestBase, originalRequest: SdkHttpRequest) -> SdkHttpRequestBuilder {
         headers = convertSignedHeadersToHeaders(crtRequest: crtRequest)
         methodType = originalRequest.method
@@ -78,6 +84,10 @@ extension SdkHttpRequestBuilder {
             let pathAndQueryItems = URLComponents(string: crtRequest.path)
             path = pathAndQueryItems?.path ?? "/"
             queryItems = pathAndQueryItems?.percentEncodedQueryItems ?? [URLQueryItem]()
+        } else if let _ = crtRequest as? HTTP2Request {
+            assertionFailure("HTTP2Request not supported")
+        } else {
+            assertionFailure("Unknown request type")
         }
         return self
     }

--- a/Sources/ClientRuntime/Networking/Http/SdkHttpRequest.swift
+++ b/Sources/ClientRuntime/Networking/Http/SdkHttpRequest.swift
@@ -84,7 +84,7 @@ extension SdkHttpRequestBuilder {
             let pathAndQueryItems = URLComponents(string: crtRequest.path)
             path = pathAndQueryItems?.path ?? "/"
             queryItems = pathAndQueryItems?.percentEncodedQueryItems ?? [URLQueryItem]()
-        } else if let _ = crtRequest as? HTTP2Request {
+        } else if crtRequest as? HTTP2Request != nil {
             assertionFailure("HTTP2Request not supported")
         } else {
             assertionFailure("Unknown request type")

--- a/Sources/ClientRuntime/Networking/Http/SdkHttpRequest.swift
+++ b/Sources/ClientRuntime/Networking/Http/SdkHttpRequest.swift
@@ -70,18 +70,19 @@ extension SdkHttpRequest: CustomDebugStringConvertible, CustomStringConvertible 
 }
 
 extension SdkHttpRequestBuilder {
-    public func update(from crtRequest: HTTPRequest, originalRequest: SdkHttpRequest) -> SdkHttpRequestBuilder {
+    public func update(from crtRequest: HTTPRequestBase, originalRequest: SdkHttpRequest) -> SdkHttpRequestBuilder {
         headers = convertSignedHeadersToHeaders(crtRequest: crtRequest)
         methodType = originalRequest.method
         host = originalRequest.endpoint.host
-        let pathAndQueryItems = URLComponents(string: crtRequest.path)
-        path = pathAndQueryItems?.path ?? "/"
-        queryItems = pathAndQueryItems?.percentEncodedQueryItems ?? [URLQueryItem]()
-
+        if let crtRequest = crtRequest as? HTTPRequest {
+            let pathAndQueryItems = URLComponents(string: crtRequest.path)
+            path = pathAndQueryItems?.path ?? "/"
+            queryItems = pathAndQueryItems?.percentEncodedQueryItems ?? [URLQueryItem]()
+        }
         return self
     }
 
-    func convertSignedHeadersToHeaders(crtRequest: HTTPRequest) -> Headers {
+    func convertSignedHeadersToHeaders(crtRequest: HTTPRequestBase) -> Headers {
         return Headers(httpHeaders: crtRequest.getHeaders())
     }
 }

--- a/Sources/SmithyTestUtil/ResponseTestUtil/HttpResponseTestBase.swift
+++ b/Sources/SmithyTestUtil/ResponseTestUtil/HttpResponseTestBase.swift
@@ -27,7 +27,7 @@ open class HttpResponseTestBase: XCTestCase {
 
         return HttpResponse(headers: internalHeaders,
                             body: content,
-                            statusCode: HttpStatusCode(rawValue: code) ?? HttpStatusCode.badRequest)
+                            statusCode: HttpStatusCode(rawValue: Int(code)) ?? HttpStatusCode.badRequest)
 
     }
 }

--- a/Tests/ClientRuntimeTests/ClientRuntimeTests/NetworkingTests/ClientErrorTests.swift
+++ b/Tests/ClientRuntimeTests/ClientRuntimeTests/NetworkingTests/ClientErrorTests.swift
@@ -101,7 +101,7 @@ class ClientErrorTests: XCTestCase {
     }
 
     func test_waiterErrorType_returnsNilForCRTError() async throws {
-        let crtError = CRTError(code: 2)
+        let crtError = CommonRunTimeError.crtError(.init(code: 2))
         let subject = ClientError.crtError(crtError)
         XCTAssertNil(subject.waiterErrorType)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

Fixes https://github.com/awslabs/aws-sdk-swift/issues/835

Related https://github.com/awslabs/aws-sdk-swift/pull/862

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


### Motivation

We have new aws-crt-swift version available which has breaking changes.

### Changes

- Pass bootstrap parameter
- HTTP Client in CRT now accepts updated callbacks which no longer has stream. Hence, updated the callback uses to reflect the changes.

### Result

- No functional changes
- Verified S3 list bucket and get object operation
- 
## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.