### PR TITLE
fix: Update aws-crt-swift to 0.6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "SmithyTestUtil", targets: ["SmithyTestUtil"])
     ],
     dependencies: [
-        .package(url: "https://github.com/awslabs/aws-crt-swift.git", .exact("0.6.0")),
+        .package(url: "https://github.com/awslabs/aws-crt-swift.git", .exact("0.6.1")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/MaxDesiatov/XMLCoder.git", from: "0.13.0")
     ],


### PR DESCRIPTION
## Issue \#
Pulls in fix for https://github.com/awslabs/aws-sdk-swift/issues/867

## Description of changes
Fixes an issue that prevents the SDK from building to an iOS device when building on a M series Mac.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.