### PR TITLE
fix: remove build error for Swift 5.8

### DIFF
--- a/Sources/ClientRuntime/Util/SwiftVersion.swift
+++ b/Sources/ClientRuntime/Util/SwiftVersion.swift
@@ -6,12 +6,14 @@
 //
 
 public var swiftVersion: String {
-    #if swift(>=5.8)
+    #if swift(>=5.9)
       #error("""
           Cannot use a version of Swift greater than available. \
           Please create a Github issue for us to add support for the version of Swift you want to use.
           """
       )
+    #elseif swift(>=5.8)
+    return "5.8"
     #elseif swift(>=5.7)
     return "5.7"
     #elseif swift(>=5.6)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
related issue downstream: https://github.com/aws-amplify/amplify-swift/issues/2771

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Xcode 14.3 beta was released on 2/16 [[release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-14_3-release-notes)] with Swift 5.8. The `swiftVersion` property in ClientRuntime currently errors on >= 5.8, preventing anyone consuming it (directly or transitively) from building using Xcode 14.3 beta. This change bumps the "allowed" Swift version to 5.8.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.