### PR TITLE
fix: Reading from a `DataStreamReader` with `rewind: true` properly rewinds the stream allowing for subsequent reads.

### DIFF
--- a/Sources/ClientRuntime/Networking/Streaming/DataStreamReader.swift
+++ b/Sources/ClientRuntime/Networking/Streaming/DataStreamReader.swift
@@ -36,7 +36,7 @@ public class DataStreamReader: StreamReader {
 
     init(byteBuffer: ByteBuffer = ByteBuffer(size: 0)) {
         self.byteBuffer = byteBuffer
-        self._availableForRead = 0
+        self._availableForRead = UInt(byteBuffer.length())
         self.offset = 0
         self._hasFinishedWriting = false
     }
@@ -51,9 +51,16 @@ public class DataStreamReader: StreamReader {
                 bytesRead = byteBuffer.read(buffer: typedBuffer)
             }
 
-            if !rewind, let bytesRead = bytesRead {
-                _availableForRead -= UInt(bytesRead)
-                offset += UInt(bytesRead)
+            if let bytesRead = bytesRead {
+                if rewind {
+                    try? byteBuffer.seek(
+                        offset: Int64(offset),
+                        streamSeekType: .begin
+                    )
+                } else {
+                    _availableForRead -= UInt(bytesRead)
+                    offset += UInt(bytesRead)
+                }
             }
         }
         return ByteBuffer(data: data)

--- a/Tests/ClientRuntimeTests/StreamingTests/DataStreamReaderTests.swift
+++ b/Tests/ClientRuntimeTests/StreamingTests/DataStreamReaderTests.swift
@@ -1,0 +1,37 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import ClientRuntime
+import AwsCommonRuntimeKit
+import XCTest
+
+class DataStreamReaderTests: XCTestCase {
+    let testData = Data([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A])
+    
+    func testRead() {
+        let byteBuffer = ByteBuffer(data: testData)
+        let dataStreamReader = DataStreamReader(byteBuffer: byteBuffer)
+        
+        let firstRead = dataStreamReader.read().getData()
+        XCTAssertEqual(firstRead, testData)
+        
+        let secondRead = dataStreamReader.read().getData()
+        XCTAssertNotEqual(secondRead, testData)
+        XCTAssertEqual(secondRead, Data())
+    }
+    
+    func testReadWithRewind() {
+        let byteBuffer = ByteBuffer(data: testData)
+        let dataStreamReader = DataStreamReader(byteBuffer: byteBuffer)
+        
+        let firstRead = dataStreamReader.read(rewind: true).getData()
+        XCTAssertEqual(firstRead, testData)
+        
+        let secondRead = dataStreamReader.read().getData()
+        XCTAssertEqual(secondRead, testData)
+    }
+}

--- a/Tests/ClientRuntimeTests/StreamingTests/DataStreamReaderTests.swift
+++ b/Tests/ClientRuntimeTests/StreamingTests/DataStreamReaderTests.swift
@@ -34,4 +34,21 @@ class DataStreamReaderTests: XCTestCase {
         let secondRead = dataStreamReader.read().getData()
         XCTAssertEqual(secondRead, testData)
     }
+    
+    func testWriteThenReadWithRewind() {
+        let dataStreamReader = DataStreamReader()
+        
+        let byteBuffer = ByteBuffer(data: testData)
+        dataStreamReader.write(buffer: byteBuffer)
+        
+        let firstRead = dataStreamReader.read(rewind: true).getData()
+        XCTAssertEqual(firstRead, testData)
+        
+        let secondRead = dataStreamReader.read().getData()
+        XCTAssertEqual(secondRead, testData)
+        
+        let thirdRead = dataStreamReader.read().getData()
+        XCTAssertNotEqual(thirdRead, testData)
+        XCTAssertEqual(thirdRead, Data())
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes an issue where subsequent reads from a DataStreamReader would return an unexpected value when the preceding read specified `rewind: true`. 

Passing in `rewind: true` when reading from a DataStreamReader should allow the next read to also read the same data. 

## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/865

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.