### PR TITLE
feat: Allow multiple @_spi() imports in code generated Swift

### DIFF
--- a/smithy-swift-codegen/src/test/kotlin/ImportDeclarationsTest.kt
+++ b/smithy-swift-codegen/src/test/kotlin/ImportDeclarationsTest.kt
@@ -32,4 +32,51 @@ class ImportDeclarationsTest {
         val expected = "import Foundation"
         assertEquals(expected, statements)
     }
+
+    @Test
+    fun `it renders @testable declarations`() {
+        val subject = ImportDeclarations()
+        subject.addImport("MyPackage", true)
+        assertEquals("@testable import MyPackage", subject.toString())
+    }
+
+    @Test
+    fun `it preserves @testable declarations`() {
+        val subject = ImportDeclarations()
+        subject.addImport("MyPackage", true)
+        subject.addImport("MyPackage", false)
+        assertEquals("@testable import MyPackage", subject.toString())
+    }
+
+    @Test
+    fun `it renders a single @_spi() declaration`() {
+        val subject = ImportDeclarations()
+        subject.addImport("MyPackage", false, "MyInternalAPI")
+        assertEquals("@_spi(MyInternalAPI) import MyPackage", subject.toString())
+    }
+
+    @Test
+    fun `it renders a single @_spi() and @testable declaration`() {
+        val subject = ImportDeclarations()
+        subject.addImport("MyPackage", true, "MyInternalAPI")
+        assertEquals("@testable @_spi(MyInternalAPI) import MyPackage", subject.toString())
+    }
+
+    @Test
+    fun `it renders multiple @_spi() declarations`() {
+        val subject = ImportDeclarations()
+        subject.addImport("MyPackage", false, "MyInternalAPI1")
+        subject.addImport("MyPackage", false, "MyInternalAPI2")
+        assertEquals("@_spi(MyInternalAPI1) @_spi(MyInternalAPI2) import MyPackage", subject.toString())
+    }
+
+    @Test
+    fun `it deduplicates @_spi() declarations`() {
+        val subject = ImportDeclarations()
+        subject.addImport("MyPackage", false, "MyInternalAPI1")
+        subject.addImport("MyPackage", false, "MyInternalAPI2")
+        subject.addImport("MyPackage", false, "MyInternalAPI1")
+        subject.addImport("MyPackage", false, "MyInternalAPI2")
+        assertEquals("@_spi(MyInternalAPI1) @_spi(MyInternalAPI2) import MyPackage", subject.toString())
+    }
 }


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/947

## Description of changes
Allows code-generated Swift import statements to have multiple `@spi()` annotations so that multiple system programming interfaces may be used in the same Swift source file.  (Currently only `Internal` may be imported as a SPI.)
- Module imports now maintain a set of SPI names, instead of a single optional name.
- Add tests for proper import generation.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.