### PR TITLE
feat: Forces http2 for bidirectional event streams

### DIFF
--- a/Sources/ClientRuntime/EventStream/DefaultMessageDecoderStream.swift
+++ b/Sources/ClientRuntime/EventStream/DefaultMessageDecoderStream.swift
@@ -60,7 +60,11 @@ extension EventStream {
         }
 
         public func makeAsyncIterator() -> AsyncIterator {
-            AsyncIterator(stream: stream, messageDecoder: messageDecoder, responseDecoder: responseDecoder)
+            AsyncIterator(
+                stream: stream,
+                messageDecoder: messageDecoder,
+                responseDecoder: responseDecoder
+            )
         }
     }
 }

--- a/Sources/ClientRuntime/EventStream/DefaultMessageDecoderStream.swift
+++ b/Sources/ClientRuntime/EventStream/DefaultMessageDecoderStream.swift
@@ -6,39 +6,39 @@
 //
 
 extension EventStream {
-    
+
     /// Stream adapter that decodes input data into `EventStream.Message` objects.
     public struct DefaultMessageDecoderStream<Event: MessageUnmarshallable>: MessageDecoderStream {
         public typealias Element = Event
-        
+
         let stream: Stream
         let messageDecoder: MessageDecoder
         let responseDecoder: ResponseDecoder
-        
+
         public init(stream: Stream, messageDecoder: MessageDecoder, responseDecoder: ResponseDecoder) {
             self.stream = stream
             self.messageDecoder = messageDecoder
             self.responseDecoder = responseDecoder
         }
-        
+
         public struct AsyncIterator: AsyncIteratorProtocol {
             let stream: Stream
             let messageDecoder: MessageDecoder
             let responseDecoder: ResponseDecoder
-            
+
             init(stream: Stream, messageDecoder: MessageDecoder, responseDecoder: ResponseDecoder) {
                 self.stream = stream
                 self.messageDecoder = messageDecoder
                 self.responseDecoder = responseDecoder
             }
-            
+
             mutating public func next() async throws -> Event? {
                 // if we have a message in the decoder buffer, return it
                 if let message = try messageDecoder.message() {
                     let event = try Event(message: message, decoder: responseDecoder)
                     return event
                 }
-                
+
                 // read until the end of the stream
                 while let data = try stream.read(upToCount: Int.max) {
                     // feed the data to the decoder
@@ -51,7 +51,7 @@ extension EventStream {
                         return event
                     }
                 }
-                
+
                 // this is the end of the stream
                 // notify the decoder that the stream has ended
                 try messageDecoder.endOfStream()

--- a/Sources/ClientRuntime/EventStream/DefaultMessageDecoderStream.swift
+++ b/Sources/ClientRuntime/EventStream/DefaultMessageDecoderStream.swift
@@ -44,7 +44,7 @@ extension EventStream {
                     // feed the data to the decoder
                     // this may result in a message being returned
                     try messageDecoder.feed(data: data)
-                    
+
                     // if we have a message in the decoder buffer, return it
                     if let message = try messageDecoder.message() {
                         let event = try Element(message: message, decoder: responseDecoder)
@@ -58,7 +58,7 @@ extension EventStream {
                 return nil
             }
         }
-        
+
         public func makeAsyncIterator() -> AsyncIterator {
             AsyncIterator(
                 stream: stream,

--- a/Sources/ClientRuntime/EventStream/DefaultMessageDecoderStream.swift
+++ b/Sources/ClientRuntime/EventStream/DefaultMessageDecoderStream.swift
@@ -6,59 +6,59 @@
 //
 
 extension EventStream {
-
+    
     /// Stream adapter that decodes input data into `EventStream.Message` objects.
     public struct DefaultMessageDecoderStream<Event: MessageUnmarshallable>: MessageDecoderStream {
         public typealias Element = Event
-
+        
         let stream: Stream
         let messageDecoder: MessageDecoder
         let responseDecoder: ResponseDecoder
-
+        
         public init(stream: Stream, messageDecoder: MessageDecoder, responseDecoder: ResponseDecoder) {
             self.stream = stream
             self.messageDecoder = messageDecoder
             self.responseDecoder = responseDecoder
         }
-
+        
         public struct AsyncIterator: AsyncIteratorProtocol {
             let stream: Stream
             let messageDecoder: MessageDecoder
             let responseDecoder: ResponseDecoder
-
+            
             init(stream: Stream, messageDecoder: MessageDecoder, responseDecoder: ResponseDecoder) {
                 self.stream = stream
                 self.messageDecoder = messageDecoder
                 self.responseDecoder = responseDecoder
             }
-
+            
             mutating public func next() async throws -> Event? {
                 // if we have a message in the decoder buffer, return it
                 if let message = try messageDecoder.message() {
                     let event = try Event(message: message, decoder: responseDecoder)
                     return event
                 }
-
+                
                 // read until the end of the stream
                 while let data = try stream.read(upToCount: Int.max) {
                     // feed the data to the decoder
                     // this may result in a message being returned
                     try messageDecoder.feed(data: data)
-
+                    
                     // if we have a message in the decoder buffer, return it
                     if let message = try messageDecoder.message() {
                         let event = try Element(message: message, decoder: responseDecoder)
                         return event
                     }
                 }
-
+                
                 // this is the end of the stream
                 // notify the decoder that the stream has ended
                 try messageDecoder.endOfStream()
                 return nil
             }
         }
-
+        
         public func makeAsyncIterator() -> AsyncIterator {
             AsyncIterator(
                 stream: stream,

--- a/Sources/ClientRuntime/EventStream/DefaultMessageEncoderStream.swift
+++ b/Sources/ClientRuntime/EventStream/DefaultMessageEncoderStream.swift
@@ -59,7 +59,7 @@ extension EventStream {
                         lastMessageSent = true
                         return data
                     }
-                    
+
                     // mark the stream as complete
                     return nil
                 }
@@ -122,13 +122,13 @@ extension EventStream {
             if !buffer.isEmpty {
                 let toRead = Swift.min(remaining, buffer.count)
                 data.append(buffer.subdata(in: 0..<toRead))
-                
+
                 // reset buffer to remaining data
                 buffer = Data(buffer.subdata(in: toRead..<buffer.count))
-                
+
                 // update remaining bytes to read
                 remaining -= toRead
-                
+
                 // update position
                 position = position.advanced(by: toRead)
             }
@@ -138,10 +138,10 @@ extension EventStream {
                 let toRead = Swift.min(remaining, next.count)
                 data.append(next[0..<toRead])
                 remaining -= toRead
-                
+
                 // update position
                 position += toRead
-                
+
                 // if we have more data, add it to the buffer
                 if next.count > toRead {
                     buffer.append(next[toRead..<next.count])

--- a/Sources/ClientRuntime/EventStream/DefaultMessageEncoderStream.swift
+++ b/Sources/ClientRuntime/EventStream/DefaultMessageEncoderStream.swift
@@ -13,39 +13,44 @@ extension EventStream {
         let messageSinger: MessageSigner
         let requestEncoder: RequestEncoder
         var readAsyncIterator: AsyncIterator?
-
-        public init(stream: AsyncThrowingStream<Event, Error>,
-                    messageEncoder: MessageEncoder,
-                    requestEncoder: RequestEncoder,
-                    messageSinger: MessageSigner) {
+        
+        public init(
+            stream: AsyncThrowingStream<Event, Error>,
+            messageEncoder: MessageEncoder,
+            requestEncoder: RequestEncoder,
+            messageSinger: MessageSigner
+        ) {
             self.stream = stream
             self.messageEncoder = messageEncoder
             self.messageSinger = messageSinger
             self.requestEncoder = requestEncoder
             self.readAsyncIterator = makeAsyncIterator()
         }
-
+        
         public struct AsyncIterator: AsyncIteratorProtocol {
             let stream: AsyncThrowingStream<Event, Error>
             let messageEncoder: MessageEncoder
             var messageSinger: MessageSigner
             let requestEncoder: RequestEncoder
-
+            
             private var lastMessageSent: Bool = false
-
-            init(stream: AsyncThrowingStream<Event, Error>,
-                 messageEncoder: MessageEncoder,
-                 requestEncoder: RequestEncoder,
-                 messageSinger: MessageSigner) {
+            private var streamIterator: AsyncThrowingStream<Event, Error>.Iterator
+            
+            init(
+                stream: AsyncThrowingStream<Event, Error>,
+                messageEncoder: MessageEncoder,
+                requestEncoder: RequestEncoder,
+                messageSinger: MessageSigner
+            ) {
                 self.stream = stream
+                self.streamIterator = stream.makeAsyncIterator()
                 self.messageEncoder = messageEncoder
                 self.messageSinger = messageSinger
                 self.requestEncoder = requestEncoder
             }
-
+            
             mutating public func next() async throws -> Data? {
-                var iterator = stream.makeAsyncIterator()
-                guard let event = try await iterator.next() else {
+                guard let event = try await streamIterator.next() else {
                     // There are no more messages in the base stream
                     // if we have not sent the last message, send it now
                     guard lastMessageSent else {
@@ -54,105 +59,107 @@ extension EventStream {
                         lastMessageSent = true
                         return data
                     }
-
+                    
                     // mark the stream as complete
                     return nil
                 }
-
+                
                 // marshall event to message
                 let message = try event.marshall(encoder: requestEncoder)
-
+                
                 // sign the message
                 let signedMessage = try await messageSinger.sign(message: message)
-
+                
                 // encode again the signed message
                 let data = try messageEncoder.encode(message: signedMessage)
                 return data
             }
         }
-
+        
         public func makeAsyncIterator() -> AsyncIterator {
-            AsyncIterator(stream: stream,
-                          messageEncoder: messageEncoder,
-                          requestEncoder: requestEncoder,
-                          messageSinger: messageSinger)
+            AsyncIterator(
+                stream: stream,
+                messageEncoder: messageEncoder,
+                requestEncoder: requestEncoder,
+                messageSinger: messageSinger
+            )
         }
-
+        
         // MARK: Stream
-
+        
         /// Returns the current position in the stream
         public var position: ClientRuntime.Data.Index = 0
-
+        
         /// Returns nil because the length of async stream is not known
         public var length: Int?
-
+        
         /// Returns false because the length of async stream is not known
         /// and therefore cannot be empty
         public var isEmpty: Bool = false
-
+        
         /// Returns false because async stream is not seekable
         public var isSeekable: Bool = false
-
+        
         /// Internal buffer to store excess data read from async stream
         var buffer = Data()
-
+        
         public func read(upToCount count: Int) throws -> ClientRuntime.Data? {
             fatalError("read(upToCount:) is not supported by AsyncStream backed streams")
         }
-
+        
         public func readToEnd() throws -> ClientRuntime.Data? {
             fatalError("readToEnd() is not supported by AsyncStream backed streams")
         }
-
+        
         /// Reads up to `count` bytes from the stream asynchronously
         /// - Parameter count: maximum number of bytes to read
         /// - Returns: Data read from the stream, or nil if the stream is closed and no data is available
         public func readAsync(upToCount count: Int) async throws -> Data? {
             var data = Data()
             var remaining = count
-
+            
             // read from buffer
             if !buffer.isEmpty {
                 let toRead = Swift.min(remaining, buffer.count)
                 data.append(buffer.subdata(in: 0..<toRead))
-
+                
                 // reset buffer to remaining data
                 buffer = Data(buffer.subdata(in: toRead..<buffer.count))
-
+                
                 // update remaining bytes to read
                 remaining -= toRead
-
+                
                 // update position
                 position = position.advanced(by: toRead)
             }
-
+            
             while remaining > 0, let next = try await readAsyncIterator?.next() {
                 // read from async stream
                 let toRead = Swift.min(remaining, next.count)
                 data.append(next[0..<toRead])
                 remaining -= toRead
-
+                
                 // update position
                 position += toRead
-
+                
                 // if we have more data, add it to the buffer
                 if next.count > toRead {
                     buffer.append(next[toRead..<next.count])
                 }
             }
-
+            
             // async stream has ended, return nil to mark stream end
             if data.isEmpty {
                 return nil
             }
-
+            
             return data
         }
-
+        
         public func write(contentsOf data: ClientRuntime.Data) throws {
             fatalError("write(contentsOf:) is not supported by AsyncStream backed streams")
         }
-
+        
         /// Closing the stream is a no-op because the underlying async stream is not owned by this stream
         public func close() throws {
             // no-op

--- a/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
@@ -34,7 +34,7 @@ public class CRTClientEngine: HttpClientEngine {
                 connectionPools[endpoint] = newConnectionPool // save in dictionary
                 return newConnectionPool
             }
-            
+
             return connectionPool
         }
 

--- a/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
@@ -81,8 +81,16 @@ public class CRTClientEngine: HttpClientEngine {
     }
 
     public func execute(request: SdkHttpRequest) async throws -> HttpResponse {
+//        if h2 {
+//            // USER STREAM MANAGER
+//        } else {
+//            let connectionMgr = try await serialExecutor.getOrCreateConnectionPool(endpoint: request.endpoint)
+//            let connection = try await connectionMgr.acquireConnection()
+//        }
+        
         let connectionMgr = try await serialExecutor.getOrCreateConnectionPool(endpoint: request.endpoint)
         let connection = try await connectionMgr.acquireConnection()
+        
         self.logger.debug("Connection was acquired to: \(String(describing: request.endpoint.url?.absoluteString))")
         switch connection.httpVersion {
         case .version_1_1:

--- a/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
@@ -19,12 +19,10 @@ public class CRTClientEngine: HttpClientEngine {
         private var connectionPools: [Endpoint: HTTPClientConnectionManager] = [:]
         private var http2ConnectionPools: [Endpoint: HTTP2StreamManager] = [:]
         private let sharedDefaultIO = SDKDefaultIO.shared
-        private let alpnList: [ALPNProtocol]
 
         init(config: CRTClientEngineConfig) {
             self.windowSize = config.windowSize
             self.maxConnectionsPerEndpoint = config.maxConnectionsPerEndpoint
-            self.alpnList = config.alpnList
             self.logger = SwiftLogger(label: "SerialExecutor")
         }
 
@@ -51,7 +49,6 @@ public class CRTClientEngine: HttpClientEngine {
         private func createConnectionPool(endpoint: Endpoint) throws -> HTTPClientConnectionManager {
             let tlsConnectionOptions = TLSConnectionOptions(
                 context: sharedDefaultIO.tlsContext,
-                alpnList: alpnList.map(\.rawValue),
                 serverName: endpoint.host
             )
 

--- a/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngineConfig.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngineConfig.swift
@@ -4,7 +4,7 @@
  */
 
 struct CRTClientEngineConfig {
-
+    
     /// Max connections the manager can contain per endpoint
     let maxConnectionsPerEndpoint: Int
 
@@ -16,9 +16,9 @@ struct CRTClientEngineConfig {
     /// you're testing and don't want to fool around with CA trust stores.
     /// If you set this in server mode, it enforces client authentication.
     let verifyPeer: Bool
-    
+
     let alpnList: [ALPNProtocol]
-    
+
     public init(
         maxConnectionsPerEndpoint: Int = 50,
         windowSize: Int = 16 * 1024 * 1024,

--- a/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngineConfig.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngineConfig.swift
@@ -17,17 +17,13 @@ struct CRTClientEngineConfig {
     /// If you set this in server mode, it enforces client authentication.
     let verifyPeer: Bool
 
-    let alpnList: [ALPNProtocol]
-
     public init(
         maxConnectionsPerEndpoint: Int = 50,
         windowSize: Int = 16 * 1024 * 1024,
-        verifyPeer: Bool = true,
-        alpnList: [ALPNProtocol] = [.http1]
+        verifyPeer: Bool = true
     ) {
         self.maxConnectionsPerEndpoint = maxConnectionsPerEndpoint
         self.windowSize = windowSize
         self.verifyPeer = verifyPeer
-        self.alpnList = alpnList
     }
 }

--- a/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngineConfig.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngineConfig.swift
@@ -4,7 +4,7 @@
  */
 
 struct CRTClientEngineConfig {
-    
+
     /// Max connections the manager can contain per endpoint
     let maxConnectionsPerEndpoint: Int
 

--- a/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngineConfig.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngineConfig.swift
@@ -16,12 +16,18 @@ struct CRTClientEngineConfig {
     /// you're testing and don't want to fool around with CA trust stores.
     /// If you set this in server mode, it enforces client authentication.
     let verifyPeer: Bool
-
-    public init(maxConnectionsPerEndpoint: Int = 50,
-                windowSize: Int = 16 * 1024 * 1024,
-                verifyPeer: Bool = true) {
+    
+    let alpnList: [ALPNProtocol]
+    
+    public init(
+        maxConnectionsPerEndpoint: Int = 50,
+        windowSize: Int = 16 * 1024 * 1024,
+        verifyPeer: Bool = true,
+        alpnList: [ALPNProtocol] = [.http1]
+    ) {
         self.maxConnectionsPerEndpoint = maxConnectionsPerEndpoint
         self.windowSize = windowSize
         self.verifyPeer = verifyPeer
+        self.alpnList = alpnList
     }
 }

--- a/Sources/ClientRuntime/Networking/Http/HttpContext.swift
+++ b/Sources/ClientRuntime/Networking/Http/HttpContext.swift
@@ -65,6 +65,11 @@ public class HttpContext: MiddlewareContext {
     public func isBidirectionalStreamingEnabled() -> Bool {
         return attributes.get(key: HttpContext.bidirectionalStreaming) ?? false
     }
+    
+    /// Returns `true` if the request should use `http2` and only `http2` without falling back to `http1`
+    public func shouldForceH2() -> Bool {
+        return isBidirectionalStreamingEnabled()
+    }
 }
 
 extension HttpContext {

--- a/Sources/ClientRuntime/Networking/Http/ProtocolType.swift
+++ b/Sources/ClientRuntime/Networking/Http/ProtocolType.swift
@@ -9,3 +9,9 @@ public enum ProtocolType: String, CaseIterable {
     case http
     case https
 }
+
+/// The raw values correspond to valid Application-Layer Protocol Negotiation (ALPN) Protocol IDs (for example, http/1.1, h2, etc), as defined [here](https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids).
+public enum ALPNProtocol: String {
+    case http1 = "http/1.1"
+    case http2 = "h2"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR forces http2 for bidirectional event streams and updates the CRT http engine, to use a http2 specific connection manager when forcing http2. 

## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/870

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.