### PR TITLE
fix: Fix Hashable compliance on Header type

### DIFF
--- a/Sources/ClientRuntime/Networking/Http/Headers.swift
+++ b/Sources/ClientRuntime/Networking/Http/Headers.swift
@@ -186,7 +186,7 @@ extension Array where Element == Header {
     }
 }
 
-public struct Header: Hashable {
+public struct Header {
     public var name: String
     public var value: [String]
 
@@ -204,6 +204,14 @@ public struct Header: Hashable {
 extension Header: Equatable {
     public static func == (lhs: Header, rhs: Header) -> Bool {
         return lhs.name == rhs.name && lhs.value.sorted() == rhs.value.sorted()
+    }
+}
+
+extension Header: Hashable {
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+        hasher.combine(value.sorted())
     }
 }
 


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/945

## Description of changes
The linked issue describes a crash with the following message:
```
Fatal error: Duplicate keys of type 'Endpoint' were found in a Dictionary.
This usually means either that the type violates Hashable's requirements, or
that members of such a dictionary were mutated after insertion.
```

After auditing the `Endpoint` type and its components, the `Header` type was found to not meet the requirements of Hashable.  The type is fixed here.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.