### PR TITLE
fix: Provide Endpoint hasher to work around URLQueryItem bug

### DIFF
--- a/Tests/ClientRuntimeTests/NetworkingTests/EndpointTests.swift
+++ b/Tests/ClientRuntimeTests/NetworkingTests/EndpointTests.swift
@@ -1,0 +1,31 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+@testable import ClientRuntime
+
+class EndpointTests: XCTestCase {
+    let url = URL(string: "https://xctest.amazonaws.com?abc=def&ghi=jkl&mno=pqr")!
+
+    func test_queryItems_setsQueryItemsFromURLInOrder() throws {
+        let endpoint = try Endpoint(url: url)
+        let expectedQueryItems = [
+            URLQueryItem(name: "abc", value: "def"),
+            URLQueryItem(name: "ghi", value: "jkl"),
+            URLQueryItem(name: "mno", value: "pqr")
+        ]
+        XCTAssertEqual(endpoint.queryItems, expectedQueryItems)
+    }
+
+    func test_hashableAndEquatable_hashesMatchWhenURLQueryItemsAreEqual() throws {
+        let endpoint1 = try Endpoint(url: url)
+        let endpoint2 = try Endpoint(url: url)
+        XCTAssertEqual(endpoint1, endpoint2)
+        XCTAssertEqual(endpoint1.hashValue, endpoint2.hashValue)
+    }
+}


### PR DESCRIPTION
## Issue \#
Fixes https://github.com/awslabs/aws-sdk-swift/issues/945

## Description of changes
It was discovered while investigating the issue linked above that the Linux implementation of Foundation's `URLQueryItem` does not implement the `Hashable` protocol correctly.  This ticket is filed in the `swift-corelibs-foundation` project to identify & track the issue:
https://github.com/apple/swift-corelibs-foundation/issues/4737

In the interim, this PR provides an implementation of `Hashable` for the `Endpoint` type that will allow `Endpoint` to meet the contract for hashability, by hashing query items with a private type that will hash correctly on all platforms.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.