### PR TITLE
fix: Prevents event-streams from hogging CPU

### DIFF
--- a/Sources/ClientRuntime/EventStream/DefaultMessageDecoderStream.swift
+++ b/Sources/ClientRuntime/EventStream/DefaultMessageDecoderStream.swift
@@ -40,7 +40,7 @@ extension EventStream {
                 }
 
                 // read until the end of the stream
-                while let data = try stream.read(upToCount: Int.max) {
+                while let data = try await stream.readAsync(upToCount: Int.max) {
                     // feed the data to the decoder
                     // this may result in a message being returned
                     try messageDecoder.feed(data: data)

--- a/Sources/ClientRuntime/Networking/Streaming/Stream.swift
+++ b/Sources/ClientRuntime/Networking/Streaming/Stream.swift
@@ -87,12 +87,22 @@ extension Stream {
         try await withUnsafeThrowingContinuation { continuation in
             Task {
                 do {
-                    let data = try read(upToCount: count)
+                    func getData() async throws -> Data? {
+                        while let data = try read(upToCount: count) {
+                            guard !data.isEmpty else {
+                                try await Task.sleep(nanoseconds: 1_000_000)
+                                continue
+                            }
+                            return data
+                        }
+                        return nil
+                    }
+                    let data = try await getData()
                     continuation.resume(returning: data)
                 } catch {
                     continuation.resume(throwing: error)
                 }
-            }
+           }
         }
     }
 }

--- a/Sources/ClientRuntime/Networking/Streaming/Stream.swift
+++ b/Sources/ClientRuntime/Networking/Streaming/Stream.swift
@@ -102,7 +102,7 @@ extension Stream {
                 } catch {
                     continuation.resume(throwing: error)
                 }
-           }
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pr adjusts while-loop tick rate to 1ms which reduces the CPU usage of event streams from 100%+ down to ~9%

## Issue \#
[<!--- If it fixes an open issue, please link to the issue here -->](https://github.com/awslabs/aws-sdk-swift/issues/974)

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.