### PR TITLE
fix: endpoint path encoding

### DIFF
--- a/Sources/ClientRuntime/Networking/Endpoint.swift
+++ b/Sources/ClientRuntime/Networking/Endpoint.swift
@@ -65,7 +65,7 @@ public extension Endpoint {
         var components = URLComponents()
         components.scheme = protocolType?.rawValue
         components.host = host
-        components.path = path
+        components.percentEncodedPath = path
         components.percentEncodedQueryItems = queryItems
 
         return components.url

--- a/Tests/ClientRuntimeTests/NetworkingTests/EndpointTests.swift
+++ b/Tests/ClientRuntimeTests/NetworkingTests/EndpointTests.swift
@@ -28,4 +28,26 @@ class EndpointTests: XCTestCase {
         XCTAssertEqual(endpoint1, endpoint2)
         XCTAssertEqual(endpoint1.hashValue, endpoint2.hashValue)
     }
+
+    func test_path_percentEncodedInput() throws {
+        let endpoint = Endpoint(
+            host: "xctest.amazonaws.com",
+            path: "/abc%2Bdef",
+            protocolType: .https
+        )
+        let foundationURL = try XCTUnwrap(endpoint.url)
+        let absoluteString = foundationURL.absoluteString
+        XCTAssertEqual(absoluteString, "https://xctest.amazonaws.com/abc%2Bdef")
+    }
+
+    func test_path_unencodedInput() throws {
+        let endpoint = Endpoint(
+            host: "xctest.amazonaws.com",
+            path: "/abc+def",
+            protocolType: .https
+        )
+        let foundationURL = try XCTUnwrap(endpoint.url)
+        let absoluteString = foundationURL.absoluteString
+        XCTAssertEqual(absoluteString, "https://xctest.amazonaws.com/abc+def")
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/aws-amplify/amplify-swift/issues/2743

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
```swift
let input = PutObjectInput(bucket: "foo", key: "abc+def")
let presignedURL = try await input.presignURL(config: config, expiration: expiration)
```
Today, this results in `https://<host>/abc%252Bdef?<query>`. Note that the `+` is double encoded. This is because the signing implementation encodes the path, then when `endpoint.url` is called, that [encoded path is assigned directly](https://github.com/awslabs/smithy-swift/blob/main/Sources/ClientRuntime/Networking/Endpoint.swift#L68) to `components.path`. This results in a double encoded path when retrieving the `url` [here](https://github.com/awslabs/smithy-swift/blob/main/Sources/ClientRuntime/Networking/Endpoint.swift#L71). 

This means the signature is generated with the (correctly) single encoded path `abc%2Bdef`, but the request is ultimately made with double encoded `abc%252Bdef`. 

The fix is simple, assign the already encoded path to `components.percentEncodedPath`.

**Won't this break non-encoded paths?**
Nope 😄  
```swift
  1> import Foundation

// assign percent encoded path to `percentEncodedPath`
  2> var c1 = URLComponents()
c1: Foundation.URLComponents = {}
  3> c1.scheme = "https"
  4> c1.host = "foo.bar"
  5> c1.percentEncodedPath = "/abc%2Bdef"
  6> c1.url
$R0: Foundation.URL? = "https://foo.bar/abc%2Bdef"

// assign non percent encoded path to `percentEncodedPath`
  7> var c2 = URLComponents()
c2: Foundation.URLComponents = {}
  8> c2.scheme = "https"
  9> c2.host = "foo.bar"
 10> c2.percentEncodedPath = "/abc+def"
 11> c2.url
$R1: Foundation.URL? = "https://foo.bar/abc+def"

// assign non percent encoded path to `path`
12> var c3 = URLComponents()
c3: Foundation.URLComponents = {}
 13> c3.scheme = "https"
 14> c3.host = "foo.bar"
 15> c3.path = "/abc+def"
 16> c3.url
$R3: Foundation.URL? = "https://foo.bar/abc+def"

// to demonstrate today's behavior
 17> c3.path = "/abc%2Bdef"
 18> c3.url
$R4: Foundation.URL? = "https://foo.bar/abc%252Bdef"
```

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.