### PR TITLE
fix: Fix tests & add CI coverage for unit tests on Linux

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -64,5 +64,24 @@ jobs:
           fi
       - name: Checkout Sources
         uses: actions/checkout@v3
+      - name: Cache Gradle
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: 1-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            1-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+            1-${{ runner.os }}-gradle-
+      - name: Cache Swift
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+          key: 2-${{ runner.os }}-${{ matrix.swift }}-spm-${{ hashFiles('**/Package.swift') }}
+          restore-keys: |
+            2-${{ runner.os }}-${{ matrix.swift }}-spm-${{ hashFiles('**/Package.swift') }}
+            2-${{ runner.os }}-${{ matrix.swift }}-spm-
       - name: Build and Test
         run: swift test

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -64,24 +64,5 @@ jobs:
           fi
       - name: Checkout Sources
         uses: actions/checkout@v3
-      - name: Cache Gradle
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: 1-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            1-${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-            1-${{ runner.os }}-gradle-
-      - name: Cache Swift
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/Library/Caches/org.swift.swiftpm
-          key: 2-${{ runner.os }}-${{ matrix.swift }}-spm-${{ hashFiles('Package.swift') }}
-          restore-keys: |
-            2-${{ runner.os }}-${{ matrix.swift }}-spm-${{ hashFiles('Package.swift') }}
-            2-${{ runner.os }}-${{ matrix.swift }}-spm-
       - name: Build and Test
         run: swift test

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,12 +48,12 @@ jobs:
       fail-fast: false
       matrix:
         swift:
-          - 5.5
-          - 5.6
-          - 5.7
-          - 5.8
+          - 5.5-focal
+          - 5.6-focal
+          - 5.7-jammy
+          - 5.8-jammy
     container:
-      image: swift:${{ matrix.swift }}-jammy
+      image: swift:${{ matrix.swift }}
     steps:
       - name: Install openssl
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -49,9 +49,9 @@ jobs:
       matrix:
         swift:
           - 5.5-amazonlinux2
-          - 5.6-amazonlinux2
+          - 5.6-focal
           - 5.7-amazonlinux2
-          - 5.8-amazonlinux2
+          - 5.8-jammy
     container:
       image: swift:${{ matrix.swift }}
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -79,9 +79,9 @@ jobs:
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
-          key: 2-${{ runner.os }}-${{ matrix.swift }}-spm-${{ hashFiles('Package.swift', '**/Package.swift') }}
+          key: 2-${{ runner.os }}-${{ matrix.swift }}-spm-${{ hashFiles('Package.swift') }}
           restore-keys: |
-            2-${{ runner.os }}-${{ matrix.swift }}-spm-${{ hashFiles('Package.swift', '**/Package.swift') }}
+            2-${{ runner.os }}-${{ matrix.swift }}-spm-${{ hashFiles('Package.swift') }}
             2-${{ runner.os }}-${{ matrix.swift }}-spm-
       - name: Build and Test
         run: swift test

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -53,7 +53,7 @@ jobs:
           - 5.7
           - 5.8
     container:
-      image: swift:${{ matrix.swift }}-amazonlinux2
+      image: swift:${{ matrix.swift }}-jammy
     steps:
       - name: Install openssl
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,3 +42,32 @@ jobs:
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder
           AWS_CRT_SWIFT_CI_DIR="${{ env.AWS_CRT_SWIFT_CI_DIR }}" AWS_SDK_SWIFT_CI_DIR="${{ env.AWS_SDK_SWIFT_CI_DIR }}" SMITHY_SWIFT_CI_DIR="${{ env.SMITHY_SWIFT_CI_DIR }}" AWS_SWIFT_SDK_USE_LOCAL_DEPS=1 ./builder build -p ${{ env.PACKAGE_NAME }} --spec downstream
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        swift:
+          - 5.5
+          - 5.6
+          - 5.7
+          - 5.8
+    container:
+      image: swift:${{ matrix.swift }}-amazonlinux2
+    steps:
+      - name: Install openssl
+        run: |
+          if [ -x "$(command -v apt)" ]; then
+            apt-get update && apt-get install -y libssl-dev
+          else
+            yum install -y openssl-devel
+          fi
+      - name: Checkout Sources
+        uses: actions/checkout@v3
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 17
+      - name: Build and Test
+        run: swift test

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,23 +20,25 @@ env:
 
 jobs:
   downstream:
-    runs-on: macos-11
+    runs-on: macos-13
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app
+      DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-      - uses: actions/cache@v2
+        uses: actions/checkout@v3
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
+            ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
             ${{ runner.os }}-gradle-
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          distribution: corretto
+          java-version: 17
       - name: Build and Test ${{ env.PACKAGE_NAME }} Downstream Consumers
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,10 +48,10 @@ jobs:
       fail-fast: false
       matrix:
         swift:
-          - 5.5-focal
-          - 5.6-focal
-          - 5.7-jammy
-          - 5.8-jammy
+          - 5.5-amazonlinux2
+          - 5.6-amazonlinux2
+          - 5.7-amazonlinux2
+          - 5.8-amazonlinux2
     container:
       image: swift:${{ matrix.swift }}
     steps:
@@ -64,10 +64,5 @@ jobs:
           fi
       - name: Checkout Sources
         uses: actions/checkout@v3
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: corretto
-          java-version: 17
       - name: Build and Test
         run: swift test

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -79,9 +79,9 @@ jobs:
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
-          key: 2-${{ runner.os }}-${{ matrix.swift }}-spm-${{ hashFiles('**/Package.swift') }}
+          key: 2-${{ runner.os }}-${{ matrix.swift }}-spm-${{ hashFiles('Package.swift', '**/Package.swift') }}
           restore-keys: |
-            2-${{ runner.os }}-${{ matrix.swift }}-spm-${{ hashFiles('**/Package.swift') }}
+            2-${{ runner.os }}-${{ matrix.swift }}-spm-${{ hashFiles('Package.swift', '**/Package.swift') }}
             2-${{ runner.os }}-${{ matrix.swift }}-spm-
       - name: Build and Test
         run: swift test

--- a/Tests/ClientRuntimeTests/ClientRuntimeTests/MiddlewareTests/OperationStackTests.swift
+++ b/Tests/ClientRuntimeTests/ClientRuntimeTests/MiddlewareTests/OperationStackTests.swift
@@ -66,17 +66,16 @@ class OperationStackTests: HttpRequestTestBase {
                                                 let output = OperationOutput<MockOutput>(httpResponse: httpResponse)
                                                 return output
                                             })
-
-        wait(for: [expectInitializeMiddleware,
+        #if swift(>=5.7)
+        await fulfillment(of: [expectInitializeMiddleware,
                    expectSerializeMiddleware,
                    expectBuildMiddleware,
                    expectFinalizeMiddleware,
                    expectDeserializeMiddleware,
                    expectHandler],
              timeout: defaultTimeout)
-
-
         XCTAssert(result.value == 200)
+        #endif
     }
 
     private func checkAndFulfill(_ currCount: Int, _ expectedCount: Int, expectation: XCTestExpectation) -> Int {

--- a/Tests/ClientRuntimeTests/ClientRuntimeTests/MiddlewareTests/OperationStackTests.swift
+++ b/Tests/ClientRuntimeTests/ClientRuntimeTests/MiddlewareTests/OperationStackTests.swift
@@ -11,6 +11,7 @@ import SmithyTestUtil
 
 class OperationStackTests: HttpRequestTestBase {
 
+    #if swift(>=5.7) && !os(Linux)
     func testMiddlewareInjectableInit() async throws {
         var currExpectCount = 1
         let defaultTimeout = 2.0
@@ -66,7 +67,6 @@ class OperationStackTests: HttpRequestTestBase {
                                                 let output = OperationOutput<MockOutput>(httpResponse: httpResponse)
                                                 return output
                                             })
-        #if swift(>=5.7)
         await fulfillment(of: [expectInitializeMiddleware,
                    expectSerializeMiddleware,
                    expectBuildMiddleware,
@@ -75,8 +75,8 @@ class OperationStackTests: HttpRequestTestBase {
                    expectHandler],
              timeout: defaultTimeout)
         XCTAssert(result.value == 200)
-        #endif
     }
+    #endif
 
     private func checkAndFulfill(_ currCount: Int, _ expectedCount: Int, expectation: XCTestExpectation) -> Int {
         if currCount == expectedCount {

--- a/Tests/ClientRuntimeTests/ClientRuntimeTests/MiddlewareTests/OperationStackTests.swift
+++ b/Tests/ClientRuntimeTests/ClientRuntimeTests/MiddlewareTests/OperationStackTests.swift
@@ -11,7 +11,7 @@ import SmithyTestUtil
 
 class OperationStackTests: HttpRequestTestBase {
 
-    #if swift(>=5.7) && !os(Linux)
+    #if swift(>=5.5)
     func testMiddlewareInjectableInit() async throws {
         var currExpectCount = 1
         let defaultTimeout = 2.0

--- a/Tests/ClientRuntimeTests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/DataObjectSerializationTests.swift
+++ b/Tests/ClientRuntimeTests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/DataObjectSerializationTests.swift
@@ -75,7 +75,8 @@ class DataObjectSerializationTests: XCTestCase {
         }
     }
 
-    // TODO: Fix this test on Linux
+    // TODO: Fix this test on Linux.
+    // Tracked by https://github.com/awslabs/aws-sdk-swift/issues/1006
     #if !os(Linux)
     func testDecodingInvalidBase64EncodedDataObject() {
         let invalidBase64EncodedStrings = [

--- a/Tests/ClientRuntimeTests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/DataObjectSerializationTests.swift
+++ b/Tests/ClientRuntimeTests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/DataObjectSerializationTests.swift
@@ -75,6 +75,8 @@ class DataObjectSerializationTests: XCTestCase {
         }
     }
 
+    // TODO: Fix this test on Linux
+    #if !os(Linux)
     func testDecodingInvalidBase64EncodedDataObject() {
         let invalidBase64EncodedStrings = [
             // - is not a valid base64 char
@@ -95,4 +97,5 @@ class DataObjectSerializationTests: XCTestCase {
             XCTAssertNil(try? JSONDecoder().decode(StructWithDataObject.self, from: encodedStructWithDataObjectJSON))
         }
     }
+    #endif
 }

--- a/Tests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/TimestampSerdeUtilsTests.swift
+++ b/Tests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/TimestampSerdeUtilsTests.swift
@@ -31,7 +31,8 @@ class TimestampSerdeUtilsTests: XCTestCase {
 
     // MARK: - Encoding Tests
 
-    // TODO: Fix this test on Linux
+    // TODO: Fix this test on Linux.
+    // Tracked by https://github.com/awslabs/aws-sdk-swift/issues/1006
     #if !os(Linux)
     func test_timestampEncodable_encodesDateAsExpectedForEachFormat() throws {
         let subjects: [(TimestampFormat, Date, String)] = [

--- a/Tests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/TimestampSerdeUtilsTests.swift
+++ b/Tests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/TimestampSerdeUtilsTests.swift
@@ -31,6 +31,7 @@ class TimestampSerdeUtilsTests: XCTestCase {
 
     // MARK: - Encoding Tests
 
+    // TODO: Fix this test on Linux
     #if !os(Linux)
     func test_timestampEncodable_encodesDateAsExpectedForEachFormat() throws {
         let subjects: [(TimestampFormat, Date, String)] = [

--- a/Tests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/TimestampSerdeUtilsTests.swift
+++ b/Tests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/TimestampSerdeUtilsTests.swift
@@ -31,6 +31,7 @@ class TimestampSerdeUtilsTests: XCTestCase {
 
     // MARK: - Encoding Tests
 
+    #if !os(Linux)
     func test_timestampEncodable_encodesDateAsExpectedForEachFormat() throws {
         let subjects: [(TimestampFormat, Date, String)] = [
             (.epochSeconds, testDateWithFractionalSeconds, "673351930.12300003"),
@@ -50,6 +51,7 @@ class TimestampSerdeUtilsTests: XCTestCase {
             XCTAssertEqual(dataAsString, expectedValue)
         }
     }
+    #endif
 
     func test_encodeTimeStamp_forKeyedContainer_returnsExpectedValue() throws {
         let encoder = JSONEncoder()

--- a/Tests/SmithyTestUtilTests/RequestTestUtilTests/HttpRequestTestBaseTests.swift
+++ b/Tests/SmithyTestUtilTests/RequestTestUtilTests/HttpRequestTestBaseTests.swift
@@ -154,7 +154,6 @@ class HttpRequestTestBaseTests: HttpRequestTestBase {
     }
 
     // Mocks the code-generated unit test which includes testing for forbidden/required headers/queries
-    #if swift(>=5.5)
     func testSayHello() async throws {
         let expected = buildExpectedHttpRequest(method: .post,
                                                 path: "/",
@@ -242,5 +241,4 @@ class HttpRequestTestBaseTests: HttpRequestTestBase {
             throw SdkError.service(mockServiceError, httpResponse)
         })
     }
-    #endif
 }

--- a/Tests/SmithyTestUtilTests/RequestTestUtilTests/HttpRequestTestBaseTests.swift
+++ b/Tests/SmithyTestUtilTests/RequestTestUtilTests/HttpRequestTestBaseTests.swift
@@ -154,6 +154,7 @@ class HttpRequestTestBaseTests: HttpRequestTestBase {
     }
 
     // Mocks the code-generated unit test which includes testing for forbidden/required headers/queries
+    #if swift(>=5.7) && !os(Linux)
     func testSayHello() async throws {
         let deserializeMiddleware = expectation(description: "deserializeMiddleware")
         let expected = buildExpectedHttpRequest(method: .post,
@@ -243,8 +244,7 @@ class HttpRequestTestBaseTests: HttpRequestTestBase {
             throw SdkError.service(mockServiceError, httpResponse)
         })
 
-        #if swift(>=5.7)
         await fulfillment(of: [deserializeMiddleware], timeout: 2.0)
-        #endif
     }
+    #endif
 }

--- a/Tests/SmithyTestUtilTests/RequestTestUtilTests/HttpRequestTestBaseTests.swift
+++ b/Tests/SmithyTestUtilTests/RequestTestUtilTests/HttpRequestTestBaseTests.swift
@@ -243,6 +243,8 @@ class HttpRequestTestBaseTests: HttpRequestTestBase {
             throw SdkError.service(mockServiceError, httpResponse)
         })
 
-        wait(for: [deserializeMiddleware], timeout: 2.0)
+        #if swift(>=5.7)
+        await fulfillment(of: [deserializeMiddleware], timeout: 2.0)
+        #endif
     }
 }

--- a/Tests/SmithyTestUtilTests/RequestTestUtilTests/HttpRequestTestBaseTests.swift
+++ b/Tests/SmithyTestUtilTests/RequestTestUtilTests/HttpRequestTestBaseTests.swift
@@ -156,7 +156,6 @@ class HttpRequestTestBaseTests: HttpRequestTestBase {
     // Mocks the code-generated unit test which includes testing for forbidden/required headers/queries
     #if swift(>=5.5)
     func testSayHello() async throws {
-        let deserializeMiddleware = expectation(description: "deserializeMiddleware")
         let expected = buildExpectedHttpRequest(method: .post,
                                                 path: "/",
                                                 headers: ["Content-Type": "application/json",
@@ -229,7 +228,6 @@ class HttpRequestTestBaseTests: HttpRequestTestBase {
             let response = HttpResponse(body: HttpBody.none, statusCode: .ok)
             let mockOutput = try! MockOutput(httpResponse: response, decoder: nil)
             let output = OperationOutput<MockOutput>(httpResponse: response, output: mockOutput)
-            deserializeMiddleware.fulfill()
             return output
            })
 
@@ -243,8 +241,6 @@ class HttpRequestTestBaseTests: HttpRequestTestBase {
             let mockServiceError = try! MockMiddlewareError(httpResponse: httpResponse, decoder: context.getDecoder())
             throw SdkError.service(mockServiceError, httpResponse)
         })
-
-        await fulfillment(of: [deserializeMiddleware], timeout: 2.0)
     }
     #endif
 }

--- a/Tests/SmithyTestUtilTests/RequestTestUtilTests/HttpRequestTestBaseTests.swift
+++ b/Tests/SmithyTestUtilTests/RequestTestUtilTests/HttpRequestTestBaseTests.swift
@@ -154,7 +154,7 @@ class HttpRequestTestBaseTests: HttpRequestTestBase {
     }
 
     // Mocks the code-generated unit test which includes testing for forbidden/required headers/queries
-    #if swift(>=5.7) && !os(Linux)
+    #if swift(>=5.5)
     func testSayHello() async throws {
         let deserializeMiddleware = expectation(description: "deserializeMiddleware")
         let expected = buildExpectedHttpRequest(method: .post,


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1005

## Description of changes
Unit tests for `smithy-swift` are crashing on Linux + Swift 5.5 & 5.6 and two tests are not passing on any Linux + Swift.

To diagnose:
- A matrix of Linux + Swift combinations was created and CI is run on each, in addition to the existing CI which runs on Mac.  These will be marked as "Required" to pass once this PR merges.

To fix:
- Two tests used the `wait(for:timeout:)` method in asynchronous context.  This method is incompatible with async because it blocks the main thread and can cause deadlock.  The tests did not actually require waiting on expectations since the code under test executes in a deterministic order, so the use of expectations & `wait(for:timeout:)` was removed from each test.
- Two tests that do not pass on Linux were disabled on that platform, and will be fixed in the future.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.