### PR TITLE
fix: Properly escape HTTP paths for greedy label types

### DIFF
--- a/Sources/ClientRuntime/Networking/Endpoint.swift
+++ b/Sources/ClientRuntime/Networking/Endpoint.swift
@@ -11,7 +11,6 @@ public struct Endpoint: Hashable {
     public let protocolType: ProtocolType?
     public let host: String
     public let port: Int16
-
     public let headers: Headers?
     public let properties: [String: AnyHashable]
 
@@ -67,18 +66,13 @@ extension Endpoint {
         components.host = host
         components.percentEncodedPath = path
         components.percentEncodedQuery = queryItemString
-
         return components.url
     }
 
     var queryItemString: String? {
         guard let queryItems = queryItems else { return nil }
         return queryItems.map { queryItem in
-            if let value = queryItem.value {
-                return "\(queryItem.name)=\(value)"
-            } else {
-                return queryItem.name
-            }
+            return [queryItem.name, queryItem.value].compactMap { $0 }.joined(separator: "=")
         }.joined(separator: "&")
     }
 }

--- a/Sources/ClientRuntime/Networking/Http/SdkHttpRequest.swift
+++ b/Sources/ClientRuntime/Networking/Http/SdkHttpRequest.swift
@@ -29,11 +29,10 @@ public class SdkHttpRequest {
 
 extension SdkHttpRequest {
 
-    public func toHttpRequest(escaping: Bool = false) throws -> HTTPRequest {
+    public func toHttpRequest() throws -> HTTPRequest {
         let httpRequest = try HTTPRequest()
         httpRequest.method = method.rawValue
-        let encodedPath = escaping ? endpoint.path.urlPercentEncodedForPath : endpoint.path
-        httpRequest.path = [encodedPath, endpoint.queryItemString].compactMap { $0 }.joined(separator: "?")
+        httpRequest.path = [endpoint.path, endpoint.queryItemString].compactMap { $0 }.joined(separator: "?")
         httpRequest.addHeaders(headers: headers.toHttpHeaders())
         httpRequest.body = StreamableHttpBody(body: body)
         return httpRequest
@@ -42,11 +41,10 @@ extension SdkHttpRequest {
     /// Convert the SDK request to a CRT HTTPRequestBase
     /// CRT converts the HTTPRequestBase to HTTP2Request internally if the protocol is HTTP/2
     /// - Returns: the CRT request
-    public func toHttp2Request(escaping: Bool = false) throws -> HTTPRequestBase {
+    public func toHttp2Request() throws -> HTTPRequestBase {
         let httpRequest = try HTTPRequest()
         httpRequest.method = method.rawValue
-        let encodedPath = escaping ? endpoint.path.urlPercentEncodedForPath : endpoint.path
-        httpRequest.path = [encodedPath, endpoint.queryItemString].compactMap { $0 }.joined(separator: "?")
+        httpRequest.path = [endpoint.path, endpoint.queryItemString].compactMap { $0 }.joined(separator: "?")
         httpRequest.addHeaders(headers: headers.toHttpHeaders())
 
         // HTTP2Request used with manual writes hence we need to set the body to nil

--- a/Sources/ClientRuntime/PrimitiveTypeExtensions/String+Extensions.swift
+++ b/Sources/ClientRuntime/PrimitiveTypeExtensions/String+Extensions.swift
@@ -100,8 +100,8 @@ extension String {
 }
 
 extension String {
-    public func urlPercentEncoding() -> String {
-        self.urlPercentEncodedForQuery
+    public func urlPercentEncoding(encodeForwardSlash: Bool = true) -> String {
+        encodeForwardSlash ? urlPercentEncodedForQuery : urlPercentEncodedForPath
     }
 }
 


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1043

## Description of changes
Services besides S3 that were substituting text into URL paths via the `httpLabel` trait were ending up with double-encoded  paths, which caused operations to fail.  After investigating:
- S3 keys which were being substituted into URL paths were not being escaped at all, which was the default treatment for "greedy" URL paths.  Instead of not escaping, greedy labels are now escaped with the exception of the usual allowed characters minus forward-slash (greedy labels are inherently expected to contain forward slashes since they may span more than one URL path component).
- Since escaping no longer is performed as part of converting a `smithy-swift` HTTP request to a CRT HTTP request, the option to escape when that conversion is made is removed.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.