### PR TITLE
feat: Make RetryStrategyOptions initializer public

### DIFF
--- a/Sources/ClientRuntime/Retries/ExponentialBackoffStrategy.swift
+++ b/Sources/ClientRuntime/Retries/ExponentialBackoffStrategy.swift
@@ -8,7 +8,7 @@
 import func Foundation.pow
 import struct Foundation.TimeInterval
 
-struct ExponentialBackoffStrategy: RetryBackoffStrategy {
+public struct ExponentialBackoffStrategy: RetryBackoffStrategy {
     let options: ExponentialBackoffStrategyOptions
 
     var random: () -> Double = { Double.random(in: 0.0...1.0) }
@@ -16,11 +16,15 @@ struct ExponentialBackoffStrategy: RetryBackoffStrategy {
     // values set by Retry Behavior 2.0 SEP
     let r = 2.0
 
-    init(options: ExponentialBackoffStrategyOptions = ExponentialBackoffStrategyOptions()) {
+    public init() {
+        self.init(options: ExponentialBackoffStrategyOptions())
+    }
+
+    init(options: ExponentialBackoffStrategyOptions) {
         self.options = options
     }
 
-    func computeNextBackoffDelay(attempt: Int) -> TimeInterval {
+    public func computeNextBackoffDelay(attempt: Int) -> TimeInterval {
         min(random() * pow(r, Double(attempt)), options.maxBackoff)
     }
 }

--- a/Sources/ClientRuntime/Retries/RetryStrategyOptions.swift
+++ b/Sources/ClientRuntime/Retries/RetryStrategyOptions.swift
@@ -50,13 +50,13 @@ public struct RetryStrategyOptions {
     ///   - availableCapacity: The number of available tokens in a retry quota.  Defaults to 500.
     ///   - maxCapacity: The max number of tokens in a retry quota.  Defaults to 500.
     public init(
-        backoffStrategy: RetryBackoffStrategy? = nil,
+        backoffStrategy: RetryBackoffStrategy = ExponentialBackoffStrategy(),
         maxRetriesBase: Int = 2,
         availableCapacity: Int = 500,
         maxCapacity: Int = 500,
         rateLimitingMode: RateLimitingMode = .standard
     ) {
-        self.backoffStrategy = backoffStrategy ?? ExponentialBackoffStrategy()
+        self.backoffStrategy = backoffStrategy
         self.maxRetriesBase = maxRetriesBase
         self.availableCapacity = availableCapacity
         self.maxCapacity = maxCapacity

--- a/Sources/ClientRuntime/Retries/RetryStrategyOptions.swift
+++ b/Sources/ClientRuntime/Retries/RetryStrategyOptions.swift
@@ -49,14 +49,14 @@ public struct RetryStrategyOptions {
     ///   - maxRetriesBase: The number of times to retry the initial request.  Defaults to 2.
     ///   - availableCapacity: The number of available tokens in a retry quota.  Defaults to 500.
     ///   - maxCapacity: The max number of tokens in a retry quota.  Defaults to 500.
-    init(
-        backoffStrategy: RetryBackoffStrategy = ExponentialBackoffStrategy(),
+    public init(
+        backoffStrategy: RetryBackoffStrategy? = nil,
         maxRetriesBase: Int = 2,
         availableCapacity: Int = 500,
         maxCapacity: Int = 500,
         rateLimitingMode: RateLimitingMode = .standard
     ) {
-        self.backoffStrategy = backoffStrategy
+        self.backoffStrategy = backoffStrategy ?? ExponentialBackoffStrategy()
         self.maxRetriesBase = maxRetriesBase
         self.availableCapacity = availableCapacity
         self.maxCapacity = maxCapacity


### PR DESCRIPTION
## Description of changes
Provide a public initializer for `RetryStrategyOptions` so that the AWS SDK may customize retry parameters.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.