### PR TITLE
fix: Re-enable two unit tests on Linux

### DIFF
--- a/Tests/ClientRuntimeTests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/DataObjectSerializationTests.swift
+++ b/Tests/ClientRuntimeTests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/DataObjectSerializationTests.swift
@@ -75,18 +75,12 @@ class DataObjectSerializationTests: XCTestCase {
         }
     }
 
-    // TODO: Fix this test on Linux.
-    // Tracked by https://github.com/awslabs/aws-sdk-swift/issues/1006
-    #if !os(Linux)
     func testDecodingInvalidBase64EncodedDataObject() {
         let invalidBase64EncodedStrings = [
             // - is not a valid base64 char
             "Zm9v-y==",
             // encoded length is not a multiple of 4
             "Zm9vY=",
-            // invalid padding
-            // TODO: this does not pass on Linux, it is unclear of this is in fact an invalid amount of padding.
-            "Zm9vY==="
         ]
 
         for invalidBase64EncodedString in invalidBase64EncodedStrings {
@@ -98,5 +92,4 @@ class DataObjectSerializationTests: XCTestCase {
             XCTAssertNil(try? JSONDecoder().decode(StructWithDataObject.self, from: encodedStructWithDataObjectJSON))
         }
     }
-    #endif
 }

--- a/Tests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/TimestampSerdeUtilsTests.swift
+++ b/Tests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/TimestampSerdeUtilsTests.swift
@@ -31,13 +31,28 @@ class TimestampSerdeUtilsTests: XCTestCase {
 
     // MARK: - Encoding Tests
 
-    // TODO: Fix this test on Linux.
-    // Tracked by https://github.com/awslabs/aws-sdk-swift/issues/1006
-    #if !os(Linux)
+    // Precision different in linux documented in https://github.com/awslabs/aws-sdk-swift/issues/1006
+    func test_timestampEncodable_encodeEpochSecondsDateWithFractionalSeconds() throws {
+        let encoder: JSONEncoder = JSONEncoder()
+        let timestampEncodable = TimestampEncodable(date: testDateWithFractionalSeconds, format: .epochSeconds)
+        let data = try encoder.encode(timestampEncodable)
+        let dataAsString = String(data: data, encoding: .utf8)!
+        let dataAsDouble = Double(dataAsString)!
+        XCTAssertEqual(dataAsDouble, 673351930.12300003, accuracy: 0.001)
+
+    }
+
+    func test_timestampEncodable_encodeEpochSecondsDateWithoutFractionalSeconds() throws {
+        let encoder: JSONEncoder = JSONEncoder()
+        let timestampEncodable = TimestampEncodable(date: testDateWithoutFractionalSeconds, format: .epochSeconds)
+        let data = try encoder.encode(timestampEncodable)
+        let dataAsString = String(data: data, encoding: .utf8)!
+        let dataAsInt = Int(dataAsString)!
+        XCTAssertEqual(dataAsInt, 673351930)
+    }
+
     func test_timestampEncodable_encodesDateAsExpectedForEachFormat() throws {
         let subjects: [(TimestampFormat, Date, String)] = [
-            (.epochSeconds, testDateWithFractionalSeconds, "673351930.12300003"),
-            (.epochSeconds, testDateWithoutFractionalSeconds, "673351930"),
             (.dateTime, testDateWithFractionalSeconds, "\"1991-05-04T10:12:10.123Z\""),
             (.dateTime, testDateWithoutFractionalSeconds, "\"1991-05-04T10:12:10Z\""),
             (.httpDate, testDateWithFractionalSeconds, "\"Sat, 04 May 1991 10:12:10.123 GMT\""),
@@ -53,7 +68,6 @@ class TimestampSerdeUtilsTests: XCTestCase {
             XCTAssertEqual(dataAsString, expectedValue)
         }
     }
-    #endif
 
     func test_encodeTimeStamp_forKeyedContainer_returnsExpectedValue() throws {
         let encoder = JSONEncoder()

--- a/Tests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/TimestampSerdeUtilsTests.swift
+++ b/Tests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/TimestampSerdeUtilsTests.swift
@@ -51,22 +51,36 @@ class TimestampSerdeUtilsTests: XCTestCase {
         XCTAssertEqual(dataAsInt, 673351930)
     }
 
-    func test_timestampEncodable_encodesDateAsExpectedForEachFormat() throws {
-        let subjects: [(TimestampFormat, Date, String)] = [
-            (.dateTime, testDateWithFractionalSeconds, "\"1991-05-04T10:12:10.123Z\""),
-            (.dateTime, testDateWithoutFractionalSeconds, "\"1991-05-04T10:12:10Z\""),
-            (.httpDate, testDateWithFractionalSeconds, "\"Sat, 04 May 1991 10:12:10.123 GMT\""),
-            (.httpDate, testDateWithoutFractionalSeconds, "\"Sat, 04 May 1991 10:12:10 GMT\"")
-        ]
+    func test_timestampEncodable_encodeDateTimeWithFractionalSeconds() throws {
+        let encoder: JSONEncoder = JSONEncoder()
+        let timestampEncodable = TimestampEncodable(date: testDateWithFractionalSeconds, format: .dateTime)
+        let data = try encoder.encode(timestampEncodable)
+        let dataAsString = String(data: data, encoding: .utf8)!
+        XCTAssertEqual(dataAsString, "\"1991-05-04T10:12:10.123Z\"")
+    }
 
-        let encoder = JSONEncoder()
+    func test_timestampEncodable_encodeDateTimeWithoutFractionalSeconds() throws {
+        let encoder: JSONEncoder = JSONEncoder()
+        let timestampEncodable = TimestampEncodable(date: testDateWithoutFractionalSeconds, format: .dateTime)
+        let data = try encoder.encode(timestampEncodable)
+        let dataAsString = String(data: data, encoding: .utf8)!
+        XCTAssertEqual(dataAsString, "\"1991-05-04T10:12:10Z\"")
+    }
 
-        for (format, date, expectedValue) in subjects {
-            let timestampEncodable = TimestampEncodable(date: date, format: format)
-            let data = try encoder.encode(timestampEncodable)
-            let dataAsString = String(data: data, encoding: .utf8)!
-            XCTAssertEqual(dataAsString, expectedValue)
-        }
+    func test_timestampEncodable_encodeHttpDateWithFractionalSeconds() throws {
+        let encoder: JSONEncoder = JSONEncoder()
+        let timestampEncodable = TimestampEncodable(date: testDateWithFractionalSeconds, format: .httpDate)
+        let data = try encoder.encode(timestampEncodable)
+        let dataAsString = String(data: data, encoding: .utf8)!
+        XCTAssertEqual(dataAsString, "\"Sat, 04 May 1991 10:12:10.123 GMT\"")
+    }
+
+    func test_timestampEncodable_encodeHttpDateWithoutFractionalSeconds() throws {
+        let encoder: JSONEncoder = JSONEncoder()
+        let timestampEncodable = TimestampEncodable(date: testDateWithoutFractionalSeconds, format: .httpDate)
+        let data = try encoder.encode(timestampEncodable)
+        let dataAsString = String(data: data, encoding: .utf8)!
+        XCTAssertEqual(dataAsString, "\"Sat, 04 May 1991 10:12:10 GMT\"")
     }
 
     func test_encodeTimeStamp_forKeyedContainer_returnsExpectedValue() throws {

--- a/Tests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/TimestampSerdeUtilsTests.swift
+++ b/Tests/ClientRuntimeTests/SerializationTests/SerializationUtilsTests/TimestampSerdeUtilsTests.swift
@@ -31,7 +31,7 @@ class TimestampSerdeUtilsTests: XCTestCase {
 
     // MARK: - Encoding Tests
 
-    // Precision different in linux documented in https://github.com/awslabs/aws-sdk-swift/issues/1006
+    // Precision difference in linux documented in https://github.com/awslabs/aws-sdk-swift/issues/1006
     func test_timestampEncodable_encodeEpochSecondsDateWithFractionalSeconds() throws {
         let encoder: JSONEncoder = JSONEncoder()
         let timestampEncodable = TimestampEncodable(date: testDateWithFractionalSeconds, format: .epochSeconds)


### PR DESCRIPTION
This PR addresses 2 unit tests that were failing on linux but not on mac os.

## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1006

## Description of changes
**Addressing Test Failure #1**: TimestampSerdeUtilsTests.test_timestampEncodable_encodesDateAsExpectedForEachFormat failed as in linux 673351930.12300003 was rounded to 673351930.123. Since this difference is negligble I've converted the string comparison to a Double comparison with accuracy of 0.001 to allow flexibility across platforms. There are open issues in swift-corelibs-foundation which may be relevant ([#3658](https://github.com/apple/swift-corelibs-foundation/issues/3658), [#4255](https://github.com/apple/swift-corelibs-foundation/issues/4255)).

**Addressing Test Failure #2**: DataObjectSerializationTests.testDecodingInvalidBase64EncodedDataObject failed on linux for base64 string "Zm9vY===". While technically having 3 padding characters is not a valid base64 string, the handling of extra padding can differ across platforms. According to IETF standards, "If more than the allowed number of pad characters is found at the end of the string (e.g., a base 64 string terminated with "==="), the excess pad characters MAY also be ignored" (See section 3.3 of https://www.ietf.org/rfc/rfc4648.txt)

All changes were tested using `swift test` on both mac os and linux.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.