### PR TITLE
fix: Add default value handling for a scalar member of server response struct

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeDecodeXMLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeDecodeXMLGenerator.kt
@@ -300,7 +300,7 @@ abstract class MemberShapeDecodeXMLGenerator(
         }
         val decodeVerb = if (memberTargetSymbol.isBoxed() && !isUnion || (member.hasTrait<DefaultTrait>())) "decodeIfPresent" else "decode"
         val decodedMemberName = "${memberNameUnquoted}Decoded"
-        val defaultVal = if (member.hasTrait<DefaultTrait>()) "?? ${memberTargetSymbol.defaultValue()}" else ""
+        val defaultVal = if (member.hasTrait<DefaultTrait>()) "?? ${member.getTrait(DefaultTrait::class.java).get().toNode()}" else ""
         if (unkeyed) {
             writer.write("let $decodedMemberName = try $containerName.$decodeVerb(\$N.self)", memberTargetSymbol)
         } else {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeDecodeXMLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeDecodeXMLGenerator.kt
@@ -29,7 +29,6 @@ import software.amazon.smithy.swift.codegen.integration.serde.TimestampDecodeGen
 import software.amazon.smithy.swift.codegen.integration.serde.TimestampHelpers
 import software.amazon.smithy.swift.codegen.integration.serde.xml.collection.CollectionMemberCodingKey
 import software.amazon.smithy.swift.codegen.integration.serde.xml.collection.MapKeyValue
-import software.amazon.smithy.swift.codegen.model.defaultValue
 import software.amazon.smithy.swift.codegen.model.hasTrait
 import software.amazon.smithy.swift.codegen.model.isBoxed
 import software.amazon.smithy.swift.codegen.model.recursiveSymbol

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeDecodeXMLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeDecodeXMLGenerator.kt
@@ -6,7 +6,6 @@
 package software.amazon.smithy.swift.codegen.integration.serde.xml
 
 import software.amazon.smithy.codegen.core.Symbol
-import software.amazon.smithy.model.node.NodeVisitor.Default
 import software.amazon.smithy.model.shapes.BlobShape
 import software.amazon.smithy.model.shapes.CollectionShape
 import software.amazon.smithy.model.shapes.ListShape
@@ -309,7 +308,7 @@ abstract class MemberShapeDecodeXMLGenerator(
             } else if (defaultTraitVal.toString().equals("null")) {
                 defaultValNilCoalescing = "?? nil"
             } else {
-                defaultValNilCoalescing = "?? ${defaultTraitVal}"
+                defaultValNilCoalescing = "?? $defaultTraitVal"
             }
         }
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeDecodeXMLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeDecodeXMLGenerator.kt
@@ -19,8 +19,11 @@ import software.amazon.smithy.model.traits.SparseTrait
 import software.amazon.smithy.model.traits.StreamingTrait
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.model.traits.XmlFlattenedTrait
-import software.amazon.smithy.swift.codegen.*
+import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
+import software.amazon.smithy.swift.codegen.SwiftTypes
+import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.customtraits.SwiftBoxTrait
+import software.amazon.smithy.swift.codegen.getOrNull
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.serde.MemberShapeDecodeGeneratable
 import software.amazon.smithy.swift.codegen.integration.serde.TimestampDecodeGenerator
@@ -31,6 +34,7 @@ import software.amazon.smithy.swift.codegen.model.getTrait
 import software.amazon.smithy.swift.codegen.model.hasTrait
 import software.amazon.smithy.swift.codegen.model.isBoxed
 import software.amazon.smithy.swift.codegen.model.recursiveSymbol
+import software.amazon.smithy.swift.codegen.removeSurroundingBackticks
 
 abstract class MemberShapeDecodeXMLGenerator(
     private val ctx: ProtocolGenerator.GenerationContext,
@@ -305,7 +309,7 @@ abstract class MemberShapeDecodeXMLGenerator(
                 defaultVal.toString().equals("null") -> "?? nil"
                 else -> "?? $defaultVal"
             }
-        }?: ""
+        } ?: ""
 
         if (unkeyed) {
             writer.write("let $decodedMemberName = try $containerName.$decodeVerb(\$N.self)", memberTargetSymbol)

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeDecodeXMLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/xml/MemberShapeDecodeXMLGenerator.kt
@@ -306,7 +306,7 @@ abstract class MemberShapeDecodeXMLGenerator(
             val defaultVal = trait.toNode()
             when {
                 defaultVal.isStringNode() -> "?? \"$defaultVal\""
-                defaultVal.toString().equals("null") -> "?? nil"
+                defaultVal.isNullNode() -> "?? nil"
                 else -> "?? $defaultVal"
             }
         } ?: ""

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/MemberShapeDecodeXMLGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/MemberShapeDecodeXMLGeneratorTests.kt
@@ -36,7 +36,7 @@ class MemberShapeDecodeXMLGeneratorTests {
         
             public init(from decoder: Swift.Decoder) throws {
                 let containerValues = try decoder.container(keyedBy: CodingKeys.self)
-                let stringValueDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .stringValue) ?? test
+                let stringValueDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .stringValue) ?? "test"
                 stringValue = stringValueDecoded
                 let trueBooleanValueDecoded = try containerValues.decodeIfPresent(Swift.Bool.self, forKey: .trueBooleanValue) ?? false
                 trueBooleanValue = trueBooleanValueDecoded

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/MemberShapeDecodeXMLGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/MemberShapeDecodeXMLGeneratorTests.kt
@@ -19,7 +19,7 @@ class MemberShapeDecodeXMLGeneratorTests {
         val context = setupTests("Isolated/Restxml/xml-scalarmember-default-value.smithy", "aws.protocoltests.restxml#RestXml")
         val contents = getFileContents(context.manifest, "/RestXml/models/SimpleScalarPropertiesOutputResponseBody+Decodable.swift")
         val expectedContents =
-        """
+            """
         extension SimpleScalarPropertiesOutputResponseBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case byteValue
@@ -58,7 +58,7 @@ class MemberShapeDecodeXMLGeneratorTests {
                 doubleValue = doubleValueDecoded
             }
         }
-        """.trimIndent()
+            """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
     }
     private fun setupTests(smithyFile: String, serviceShapeId: String): TestContext {

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/MemberShapeDecodeXMLGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/MemberShapeDecodeXMLGeneratorTests.kt
@@ -36,7 +36,7 @@ class MemberShapeDecodeXMLGeneratorTests {
         
             public init(from decoder: Swift.Decoder) throws {
                 let containerValues = try decoder.container(keyedBy: CodingKeys.self)
-                let stringValueDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .stringValue) ?? nil
+                let stringValueDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .stringValue) ?? test
                 stringValue = stringValueDecoded
                 let trueBooleanValueDecoded = try containerValues.decodeIfPresent(Swift.Bool.self, forKey: .trueBooleanValue) ?? false
                 trueBooleanValue = trueBooleanValueDecoded
@@ -46,11 +46,11 @@ class MemberShapeDecodeXMLGeneratorTests {
                 byteValue = byteValueDecoded
                 let shortValueDecoded = try containerValues.decodeIfPresent(Swift.Int16.self, forKey: .shortValue)
                 shortValue = shortValueDecoded
-                let integerValueDecoded = try containerValues.decodeIfPresent(Swift.Int.self, forKey: .integerValue) ?? nil
+                let integerValueDecoded = try containerValues.decodeIfPresent(Swift.Int.self, forKey: .integerValue) ?? 5
                 integerValue = integerValueDecoded
                 let longValueDecoded = try containerValues.decodeIfPresent(Swift.Int.self, forKey: .longValue)
                 longValue = longValueDecoded
-                let floatValueDecoded = try containerValues.decodeIfPresent(Swift.Float.self, forKey: .floatValue) ?? nil
+                let floatValueDecoded = try containerValues.decodeIfPresent(Swift.Float.self, forKey: .floatValue) ?? 2.4
                 floatValue = floatValueDecoded
                 let protocolDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .protocol)
                 `protocol` = protocolDecoded


### PR DESCRIPTION
This PR addresses the deserialization error where a default value is not correctly assigned to fields when they're missing from server response.

## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/602

## Description of changes
Issue #602 is resolved by properly assigning the default value (`false` in this case) to [deleteMarker](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeletedObject.html#:~:text=Contents-,DeleteMarker,-Indicates%20whether%20the) property (a boolean member) of [DeletedObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeletedObject.html) when it is not found in S3 server response due to the responding bucket not being versioned.

With this change, when the deserializer tries to decode server response to [S3:deleteObjects](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html) from a non-versioned S3 bucket, in each [DeletedObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeletedObject.html), default value is correctly assigned to be `false` to delete markers.

Same applies for any other scalar member in any other server response structure that has a default value, if that member is missing from the server response struct.

A test case is added along with the change, as the change did not break any existing tests.

All changes were tested by building the `smithy-swift` project, as well as generating all the services using the changed code generator and running `swift test` as well as protocol tests on the `aws-sdk-swift` project.

<!--- Provide a general summary of your changes in the Title above -->

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.