### PR TITLE
feat: add public initializer to WaiterOutcome

### DIFF
--- a/Sources/ClientRuntime/Waiters/WaiterOutcome.swift
+++ b/Sources/ClientRuntime/Waiters/WaiterOutcome.swift
@@ -19,4 +19,12 @@ public struct WaiterOutcome<Output> {
 
     /// The result (output object or error) that caused an `Acceptor` to match.
     public let result: Result<Output, Error>
+
+    /// Creates an instance of WaiterOutcome
+    /// - Parameter attempts: The number of operation attempts that were required for the wait to succeed.
+    /// - Parameter result: The result (output object or error) that caused an `Acceptor` to match.
+    public init(attempts: Int, result: Result<Output, Error>) {
+        self.attempts = attempts
+        self.result = result
+    }
 }


### PR DESCRIPTION
This PR addresses the inability to mock WaiterOutcome by providing a public initializer.

## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1068

## Description of changes
Add a public initializer to WaiterOutcome with required parameters attempts and result. This will allow users to create an instance of WaiterOutcome in scripts that depend on smithy-swift.

I was able to reproduce the issue in #1068 using the code provided. With this change I am able to successfully build and the error "'WaiterOutcome' initializer is inaccessible due to 'internal' protection level" no longer occurs.

## Example Usage

```
import XCTest
import AWSS3
import class Foundation.Bundle

@testable import ClientRuntime

// define a protocol with our method
protocol WaitUntilBucketExistsDefaults {
    func waitUntilBucketExists(options: WaiterOptions, input: HeadBucketInput) async throws -> WaiterOutcome<HeadBucketOutputResponse>
}

// extend the S3Client and make sure it conforms to our protocol with the method
// the below definition no longer errors on WaiterOutcome init
extension S3Client: WaitUntilBucketExistsDefaults {
    func waitUntilBucketExists(options: WaiterOptions, input: HeadBucketInput) async throws -> WaiterOutcome<HeadBucketOutputResponse> {
        let response = ClientRuntime.HttpResponse(
            statusCode: .ok
        )
        let output = try await HeadBucketOutputResponse(
            httpResponse: response
        )
        return WaiterOutcome<HeadBucketOutputResponse>(
            attempts: 1,
            result: .success(output)
        )
    }
}

// Example Function
public func createS3Bucket(bucketName: String) async -> String {
    do {
        let client = try S3Client(region: "us-east-1")
        let input = HeadBucketInput(bucket: bucketName)
        let options = WaiterOptions(maxWaitTime: 120.0, minDelay: 5.0, maxDelay: 20.0)
        let outcome = try await client.waitUntilBucketExists(options: options, input: input)
        
        switch outcome.result {
        case .success(_):
            return "SUCCESS"
        default:
            return "FAILURE"
        }
    } catch {
        print("Error occurred while waiting: \(error.localizedDescription)")
        return "ERROR"
    }
}

final class CLIToolTests: XCTestCase {
    
    public func test_createS3Bucket() async {
        let result = await createS3Bucket(bucketName: "testBucket")
        XCTAssertEqual(result, "SUCCESS")
    }
    
}
```

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.