### PR TITLE
chore: Require aws-crt-swift 0.13.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "SmithyTestUtil", targets: ["SmithyTestUtil"])
     ],
     dependencies: [
-        .package(url: "https://github.com/awslabs/aws-crt-swift.git", .exact("0.12.0")),
+        .package(url: "https://github.com/awslabs/aws-crt-swift.git", .exact("0.13.0")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/MaxDesiatov/XMLCoder.git", .exact("0.17.0"))
     ],


### PR DESCRIPTION
## Description of changes
Requires the latest stable version of `aws-crt-swift`.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.